### PR TITLE
storage_volume_snapshot: Fix crash on import

### DIFF
--- a/opc/data_source_virtual_nic.go
+++ b/opc/data_source_virtual_nic.go
@@ -61,6 +61,11 @@ func dataSourceVNICRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading vnic %s: %s", name, err)
 	}
 
+	if vnic == nil {
+		d.SetId("")
+		return nil
+	}
+
 	d.SetId(name)
 	d.Set("description", vnic.Description)
 	d.Set("mac_address", vnic.MACAddress)

--- a/opc/resource_acl.go
+++ b/opc/resource_acl.go
@@ -85,6 +85,7 @@ func resourceOPCACLRead(d *schema.ResourceData, meta interface{}) error {
 	getInput := compute.GetACLInput{
 		Name: d.Id(),
 	}
+
 	result, err := computeClient.GetACL(&getInput)
 	if err != nil {
 		// ACL does not exist
@@ -93,6 +94,11 @@ func resourceOPCACLRead(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 		return fmt.Errorf("Error reading acl %s: %s", d.Id(), err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	log.Printf("[DEBUG] Read state of acl %s: %#v", d.Id(), result)

--- a/opc/resource_image_list.go
+++ b/opc/resource_image_list.go
@@ -77,17 +77,23 @@ func resourceOPCImageListUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceOPCImageListRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*compute.ComputeClient).ImageList()
 
-	getInput := &compute.GetImageListInput{
+	input := &compute.GetImageListInput{
 		Name: d.Id(),
 	}
-	getResult, err := client.GetImageList(getInput)
+
+	result, err := client.GetImageList(input)
 	if err != nil {
 		return err
 	}
 
-	d.Set("name", getResult.Name)
-	d.Set("description", getResult.Description)
-	d.Set("default", getResult.Default)
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", result.Name)
+	d.Set("description", result.Description)
+	d.Set("default", result.Default)
 
 	return nil
 }

--- a/opc/resource_image_list_entry.go
+++ b/opc/resource_image_list_entry.go
@@ -93,25 +93,31 @@ func resourceOPCImageListEntryRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	getInput := compute.GetImageListEntryInput{
+	input := compute.GetImageListEntryInput{
 		Name:    *name,
 		Version: *version,
 	}
-	getResult, err := client.GetImageListEntry(&getInput)
+
+	result, err := client.GetImageListEntry(&input)
 	if err != nil {
 		return err
 	}
 
-	attrs, err := structure.FlattenJsonToString(getResult.Attributes)
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	attrs, err := structure.FlattenJsonToString(result.Attributes)
 	if err != nil {
 		return err
 	}
 
 	d.Set("name", name)
-	d.Set("machine_images", getResult.MachineImages)
-	d.Set("version", getResult.Version)
+	d.Set("machine_images", result.MachineImages)
+	d.Set("version", result.Version)
 	d.Set("attributes", attrs)
-	d.Set("uri", getResult.Uri)
+	d.Set("uri", result.Uri)
 
 	return nil
 }

--- a/opc/resource_instance.go
+++ b/opc/resource_instance.go
@@ -456,6 +456,12 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading instance %s: %s", name, err)
 	}
 
+	if result == nil {
+		log.Printf("[DEBUG] Instance %s not found", name)
+		d.SetId("")
+		return nil
+	}
+
 	log.Printf("[DEBUG] Instance '%s' found", name)
 
 	// Update attributes

--- a/opc/resource_ip_address_prefix_set.go
+++ b/opc/resource_ip_address_prefix_set.go
@@ -79,10 +79,11 @@ func resourceOPCIPAddressPrefixSetCreate(d *schema.ResourceData, meta interface{
 func resourceOPCIPAddressPrefixSetRead(d *schema.ResourceData, meta interface{}) error {
 	computeClient := meta.(*compute.ComputeClient).IPAddressPrefixSets()
 
-	getInput := compute.GetIPAddressPrefixSetInput{
+	input := compute.GetIPAddressPrefixSetInput{
 		Name: d.Id(),
 	}
-	result, err := computeClient.GetIPAddressPrefixSet(&getInput)
+
+	result, err := computeClient.GetIPAddressPrefixSet(&input)
 	if err != nil {
 		// IP Address Prefix Set does not exist
 		if client.WasNotFoundError(err) {
@@ -90,6 +91,11 @@ func resourceOPCIPAddressPrefixSetRead(d *schema.ResourceData, meta interface{})
 			return nil
 		}
 		return fmt.Errorf("Error reading IP Address Prefix Set %s: %s", d.Id(), err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_ip_address_reservation.go
+++ b/opc/resource_ip_address_reservation.go
@@ -77,10 +77,11 @@ func resourceOPCIPAddressReservationCreate(d *schema.ResourceData, meta interfac
 func resourceOPCIPAddressReservationRead(d *schema.ResourceData, meta interface{}) error {
 	computeClient := meta.(*compute.ComputeClient).IPAddressReservations()
 
-	getInput := compute.GetIPAddressReservationInput{
+	input := compute.GetIPAddressReservationInput{
 		Name: d.Id(),
 	}
-	result, err := computeClient.GetIPAddressReservation(&getInput)
+
+	result, err := computeClient.GetIPAddressReservation(&input)
 	if err != nil {
 		// IP Address Reservation does not exist
 		if client.WasNotFoundError(err) {
@@ -88,6 +89,11 @@ func resourceOPCIPAddressReservationRead(d *schema.ResourceData, meta interface{
 			return nil
 		}
 		return fmt.Errorf("Error reading ip address reservation %s: %s", d.Id(), err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_ip_association.go
+++ b/opc/resource_ip_association.go
@@ -65,6 +65,7 @@ func resourceOPCIPAssociationRead(d *schema.ResourceData, meta interface{}) erro
 	input := compute.GetIPAssociationInput{
 		Name: name,
 	}
+
 	result, err := computeClient.GetIPAssociation(&input)
 	if err != nil {
 		// IP Association does not exist
@@ -73,6 +74,11 @@ func resourceOPCIPAssociationRead(d *schema.ResourceData, meta interface{}) erro
 			return nil
 		}
 		return fmt.Errorf("Error reading ip association '%s': %s", name, err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_ip_network.go
+++ b/opc/resource_ip_network.go
@@ -103,7 +103,7 @@ func resourceOPCIPNetworkRead(d *schema.ResourceData, meta interface{}) error {
 		Name: name,
 	}
 
-	res, err := computeClient.GetIPNetwork(input)
+	result, err := computeClient.GetIPNetwork(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -112,13 +112,18 @@ func resourceOPCIPNetworkRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading IP Network '%s': %v", name, err)
 	}
 
-	d.Set("name", res.Name)
-	d.Set("ip_address_prefix", res.IPAddressPrefix)
-	d.Set("ip_network_exchanged", res.IPNetworkExchange)
-	d.Set("description", res.Description)
-	d.Set("public_napt_enabled", res.PublicNaptEnabled)
-	d.Set("uri", res.Uri)
-	if err := setStringList(d, "tags", res.Tags); err != nil {
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", result.Name)
+	d.Set("ip_address_prefix", result.IPAddressPrefix)
+	d.Set("ip_network_exchanged", result.IPNetworkExchange)
+	d.Set("description", result.Description)
+	d.Set("public_napt_enabled", result.PublicNaptEnabled)
+	d.Set("uri", result.Uri)
+	if err := setStringList(d, "tags", result.Tags); err != nil {
 		return err
 	}
 	return nil

--- a/opc/resource_ip_network_exchange.go
+++ b/opc/resource_ip_network_exchange.go
@@ -67,10 +67,11 @@ func resourceOPCIPNetworkExchangeRead(d *schema.ResourceData, meta interface{}) 
 	computeClient := meta.(*compute.ComputeClient).IPNetworkExchanges()
 
 	log.Printf("[DEBUG] Reading state of IP Network Exchange %s", d.Id())
-	getInput := compute.GetIPNetworkExchangeInput{
+	input := compute.GetIPNetworkExchangeInput{
 		Name: d.Id(),
 	}
-	result, err := computeClient.GetIPNetworkExchange(&getInput)
+
+	result, err := computeClient.GetIPNetworkExchange(&input)
 	if err != nil {
 		// IP NetworkExchange does not exist
 		if client.WasNotFoundError(err) {
@@ -78,6 +79,11 @@ func resourceOPCIPNetworkExchangeRead(d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 		return fmt.Errorf("Error reading ip network exchange %s: %s", d.Id(), err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_ip_reservation.go
+++ b/opc/resource_ip_reservation.go
@@ -81,10 +81,11 @@ func resourceOPCIPReservationRead(d *schema.ResourceData, meta interface{}) erro
 	computeClient := meta.(*compute.ComputeClient).IPReservations()
 
 	log.Printf("[DEBUG] Reading state of ip reservation %s", d.Id())
-	getInput := compute.GetIPReservationInput{
+	input := compute.GetIPReservationInput{
 		Name: d.Id(),
 	}
-	result, err := computeClient.GetIPReservation(&getInput)
+
+	result, err := computeClient.GetIPReservation(&input)
 	if err != nil {
 		// IP Reservation does not exist
 		if client.WasNotFoundError(err) {
@@ -92,6 +93,11 @@ func resourceOPCIPReservationRead(d *schema.ResourceData, meta interface{}) erro
 			return nil
 		}
 		return fmt.Errorf("Error reading ip reservation %s: %s", d.Id(), err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	log.Printf("[DEBUG] Read state of ip reservation %s: %#v", d.Id(), result)

--- a/opc/resource_route.go
+++ b/opc/resource_route.go
@@ -101,7 +101,7 @@ func resourceOPCRouteRead(d *schema.ResourceData, meta interface{}) error {
 		Name: name,
 	}
 
-	res, err := computeClient.GetRoute(input)
+	result, err := computeClient.GetRoute(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -110,12 +110,17 @@ func resourceOPCRouteRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading route '%s': %v", name, err)
 	}
 
-	d.Set("name", res.Name)
-	d.Set("admin_distance", res.AdminDistance)
-	d.Set("ip_address_prefix", res.IPAddressPrefix)
-	d.Set("next_hop_vnic_set", res.NextHopVnicSet)
-	d.Set("description", res.Description)
-	if err := setStringList(d, "tags", res.Tags); err != nil {
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", result.Name)
+	d.Set("admin_distance", result.AdminDistance)
+	d.Set("ip_address_prefix", result.IPAddressPrefix)
+	d.Set("next_hop_vnic_set", result.NextHopVnicSet)
+	d.Set("description", result.Description)
+	if err := setStringList(d, "tags", result.Tags); err != nil {
 		return err
 	}
 	return nil

--- a/opc/resource_sec_rule.go
+++ b/opc/resource_sec_rule.go
@@ -97,6 +97,7 @@ func resourceOPCSecRuleRead(d *schema.ResourceData, meta interface{}) error {
 	input := compute.GetSecRuleInput{
 		Name: name,
 	}
+
 	result, err := computeClient.GetSecRule(&input)
 	if err != nil {
 		// Sec Rule does not exist
@@ -105,6 +106,11 @@ func resourceOPCSecRuleRead(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 		return fmt.Errorf("Error reading sec list %s: %s", name, err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_security_application.go
+++ b/opc/resource_security_application.go
@@ -108,6 +108,7 @@ func resourceOPCSecurityApplicationRead(d *schema.ResourceData, meta interface{}
 	input := compute.GetSecurityApplicationInput{
 		Name: name,
 	}
+
 	result, err := computeClient.GetSecurityApplication(&input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
@@ -115,6 +116,11 @@ func resourceOPCSecurityApplicationRead(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 		return fmt.Errorf("Error reading security application %s: %s", name, err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_security_association.go
+++ b/opc/resource_security_association.go
@@ -70,6 +70,7 @@ func resourceOPCSecurityAssociationRead(d *schema.ResourceData, meta interface{}
 	input := compute.GetSecurityAssociationInput{
 		Name: name,
 	}
+
 	result, err := computeClient.GetSecurityAssociation(&input)
 	if err != nil {
 		// Security Association does not exist
@@ -78,6 +79,11 @@ func resourceOPCSecurityAssociationRead(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 		return fmt.Errorf("Error reading security association %s: %s", name, err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_security_ip_list.go
+++ b/opc/resource_security_ip_list.go
@@ -75,6 +75,7 @@ func resourceOPCSecurityIPListRead(d *schema.ResourceData, meta interface{}) err
 	input := compute.GetSecurityIPListInput{
 		Name: name,
 	}
+
 	result, err := computeClient.GetSecurityIPList(&input)
 	if err != nil {
 		// Security IP List does not exist
@@ -83,6 +84,11 @@ func resourceOPCSecurityIPListRead(d *schema.ResourceData, meta interface{}) err
 			return nil
 		}
 		return fmt.Errorf("Error reading security IP list %s: %s", name, err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	log.Printf("[DEBUG] Read state of security IP list %s: %#v", name, result)

--- a/opc/resource_security_list.go
+++ b/opc/resource_security_list.go
@@ -109,6 +109,7 @@ func resourceOPCSecurityListRead(d *schema.ResourceData, meta interface{}) error
 	input := compute.GetSecurityListInput{
 		Name: name,
 	}
+
 	result, err := computeClient.GetSecurityList(&input)
 	if err != nil {
 		// Security List does not exist
@@ -117,6 +118,11 @@ func resourceOPCSecurityListRead(d *schema.ResourceData, meta interface{}) error
 			return nil
 		}
 		return fmt.Errorf("Error reading security list %s: %s", name, err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_security_protocol.go
+++ b/opc/resource_security_protocol.go
@@ -88,10 +88,12 @@ func resourceOPCSecurityProtocolCreate(d *schema.ResourceData, meta interface{})
 
 func resourceOPCSecurityProtocolRead(d *schema.ResourceData, meta interface{}) error {
 	computeClient := meta.(*compute.ComputeClient).SecurityProtocols()
-	getInput := compute.GetSecurityProtocolInput{
+
+	input := compute.GetSecurityProtocolInput{
 		Name: d.Id(),
 	}
-	result, err := computeClient.GetSecurityProtocol(&getInput)
+
+	result, err := computeClient.GetSecurityProtocol(&input)
 	if err != nil {
 		// Security Protocol does not exist
 		if client.WasNotFoundError(err) {
@@ -99,6 +101,11 @@ func resourceOPCSecurityProtocolRead(d *schema.ResourceData, meta interface{}) e
 			return nil
 		}
 		return fmt.Errorf("Error reading security protocol %s: %s", d.Id(), err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_security_rule.go
+++ b/opc/resource_security_rule.go
@@ -129,10 +129,11 @@ func resourceOPCSecurityRuleCreate(d *schema.ResourceData, meta interface{}) err
 func resourceOPCSecurityRuleRead(d *schema.ResourceData, meta interface{}) error {
 	computeClient := meta.(*compute.ComputeClient).SecurityRules()
 
-	getInput := compute.GetSecurityRuleInput{
+	input := compute.GetSecurityRuleInput{
 		Name: d.Id(),
 	}
-	result, err := computeClient.GetSecurityRule(&getInput)
+
+	result, err := computeClient.GetSecurityRule(&input)
 	if err != nil {
 		// SecurityRule does not exist
 		if client.WasNotFoundError(err) {
@@ -140,6 +141,11 @@ func resourceOPCSecurityRuleRead(d *schema.ResourceData, meta interface{}) error
 			return nil
 		}
 		return fmt.Errorf("Error reading security rule %s: %s", d.Id(), err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_ssh_key.go
+++ b/opc/resource_ssh_key.go
@@ -51,6 +51,7 @@ func resourceOPCSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
 		Key:     key,
 		Enabled: enabled,
 	}
+
 	info, err := client.CreateSSHKey(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating ssh key %s: %s", name, err)
@@ -73,6 +74,7 @@ func resourceOPCSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 		Key:     key,
 		Enabled: enabled,
 	}
+
 	_, err := client.UpdateSSHKey(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating ssh key %s: %s", name, err)
@@ -88,6 +90,7 @@ func resourceOPCSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 	input := compute.GetSSHKeyInput{
 		Name: name,
 	}
+
 	result, err := computeClient.GetSSHKey(&input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
@@ -95,6 +98,11 @@ func resourceOPCSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 		return fmt.Errorf("Error reading ssh key %s: %s", name, err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("name", result.Name)

--- a/opc/resource_storage_volume.go
+++ b/opc/resource_storage_volume.go
@@ -218,6 +218,7 @@ func resourceOPCStorageVolumeRead(d *schema.ResourceData, meta interface{}) erro
 	input := compute.GetStorageVolumeInput{
 		Name: name,
 	}
+
 	result, err := sv.GetStorageVolume(&input)
 	if err != nil {
 		// Volume doesn't exist

--- a/opc/resource_storage_volume_snapshot.go
+++ b/opc/resource_storage_volume_snapshot.go
@@ -179,6 +179,12 @@ func resourceOPCStorageVolumeSnapshotRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error reading storage volume snapshot '%s': %v", name, err)
 	}
 
+	if result == nil {
+		// No Storage volume snapshot was found
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("volume_name", result.Volume)
 	d.Set("description", result.Description)
 	d.Set("name", result.Name)

--- a/opc/resource_vnic_set.go
+++ b/opc/resource_vnic_set.go
@@ -94,7 +94,7 @@ func resourceOPCVNICSetRead(d *schema.ResourceData, meta interface{}) error {
 		Name: name,
 	}
 
-	res, err := computeClient.GetVirtualNICSet(input)
+	result, err := computeClient.GetVirtualNICSet(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -103,15 +103,20 @@ func resourceOPCVNICSetRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading Virtual NIC Set '%s': %s", name, err)
 	}
 
-	d.Set("name", res.Name)
-	d.Set("description", res.Description)
-	if err := setStringList(d, "applied_acls", res.AppliedACLs); err != nil {
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", result.Name)
+	d.Set("description", result.Description)
+	if err := setStringList(d, "applied_acls", result.AppliedACLs); err != nil {
 		return err
 	}
-	if err := setStringList(d, "virtual_nics", res.VirtualNICs); err != nil {
+	if err := setStringList(d, "virtual_nics", result.VirtualNICs); err != nil {
 		return err
 	}
-	if err := setStringList(d, "tags", res.Tags); err != nil {
+	if err := setStringList(d, "tags", result.Tags); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Previously importing a storage volume snapshot with an incorrect name would panic during the Read method.

This fixes the panic and returns the correct error:

```
opc_compute_storage_volume_snapshot.foo: Importing from ID "test-acc-stor-vo-jake"...
opc_compute_storage_volume_snapshot.foo: Import complete!
  Imported opc_compute_storage_volume_snapshot (ID: test-acc-stor-vo-jake)
opc_compute_storage_volume_snapshot.foo: Refreshing state... (ID: test-acc-stor-vo-jake)
Error importing: 1 error(s) occurred:

* opc_compute_storage_volume_snapshot.foo (import id: test-acc-stor-vo-jake): 1 error(s) occurred:

* import opc_compute_storage_volume_snapshot.foo result: test-acc-stor-vo-jake: import opc_compute_storage_volume_snapshot.foo (id: test-acc-stor-vo-jake): Terraform detected a resource with this ID doesn't
exist. Please verify the ID is correct. You cannot import non-existent
resources using Terraform import.
```
Fixes: #6 