### PR TITLE
Fixing Bootable Storage Volumes

### DIFF
--- a/opc/resource_storage_volume.go
+++ b/opc/resource_storage_volume.go
@@ -144,16 +144,6 @@ func resourceOPCStorageVolumeCreate(d *schema.ResourceData, meta interface{}) er
 	imageList := d.Get("image_list").(string)
 	imageListEntry := d.Get("image_list_entry").(int)
 
-	if bootable == true {
-		if imageList == "" {
-			return fmt.Errorf("Error: A Bootable Volume must have an Image List!")
-		}
-
-		if imageListEntry == -1 {
-			return fmt.Errorf("Error: A Bootable Volume must have an Image List Entry!")
-		}
-	}
-
 	input := compute.CreateStorageVolumeInput{
 		Name:           name,
 		Description:    description,

--- a/website/docs/r/opc_compute_storage_volume.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume.html.markdown
@@ -56,8 +56,11 @@ The following arguments are supported:
 * `size` (Required) The size of this storage volume in GB. The allowed range is from 1 GB to 2 TB (2048 GB).
 * `storage_type` - (Optional) - The Type of Storage to provision. Possible values are `/oracle/public/storage/latency` or `/oracle/public/storage/default`. Defaults to `/oracle/public/storage/default`.
 * `bootable` - (Optional) Is the Volume Bootable? Defaults to `false`.
-* `image_list` - (Optional) Defines an image list. Required if `bootable` is set to `true`, optional if set to `false`.
-* `image_list_entry` - (Optional) Defines an image list entry. Required if `bootable` is set to `true`, optional if set to `false`.
+* `image_list` - (Optional) Defines an image list.
+* `image_list_entry` - (Optional) Defines an image list entry.
+* `snapshot` - (Optional) The name of the parent snapshot from which the storage volume is restored or cloned.
+* `snapshot_id` - (Optional) The Id of the parent snapshot from which the storage volume is restored or cloned.
+* `snapshot_account` - (Optional) The Account of the parent snapshot from which the storage volume is restored.
 * `tags` - (Optional) Comma-separated strings that tag the storage volume.
 
 ## Attributes Reference


### PR DESCRIPTION
- Made it possible to restore a bootable storage volume without an image list / image list entry
- Added an acceptance test for creating a vm, snapshotting the OS disk, then creating a bootable instance from it (this _could_ live in the instance tests, but it doesn't feel like the right place for it)
- Documenting the Snapshot properties on a Storage Volume

Fixes #13