### PR TITLE
F add storage containers

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ build: fmtcheck
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+		xargs -t -n4 go test $(TESTARGS) -timeout=300s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ build: fmtcheck
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=300s -parallel=4
+		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/opc/config.go
+++ b/opc/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	Endpoint       string
 	MaxRetries     int
 	Insecure       bool
-	Storage 			 bool
+	Storage        bool
 }
 
 type OPCClient struct {
@@ -69,7 +69,7 @@ func (c *Config) Client() (*OPCClient, error) {
 		computeClient: computeClient,
 	}
 
-	if &c.Storage {
+	if c.Storage {
 		storageClient, err := storage.NewStorageClient(&config)
 		if err != nil {
 			return nil, err

--- a/opc/config.go
+++ b/opc/config.go
@@ -15,13 +15,13 @@ import (
 )
 
 type Config struct {
-	User           string
-	Password       string
-	IdentityDomain string
-	Endpoint       string
-	MaxRetries     int
-	Insecure       bool
-	Storage        bool
+	User            string
+	Password        string
+	IdentityDomain  string
+	Endpoint        string
+	MaxRetries      int
+	Insecure        bool
+	StorageEndpoint string
 }
 
 type OPCClient struct {
@@ -69,7 +69,12 @@ func (c *Config) Client() (*OPCClient, error) {
 		computeClient: computeClient,
 	}
 
-	if c.Storage {
+	if c.StorageEndpoint != "" {
+		storageEndpoint, err := url.ParseRequestURI(c.StorageEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid storage endpoint URI: %s", err)
+		}
+		config.APIEndpoint = storageEndpoint
 		storageClient, err := storage.NewStorageClient(&config)
 		if err != nil {
 			return nil, err

--- a/opc/data_source_network_interface.go
+++ b/opc/data_source_network_interface.go
@@ -100,7 +100,7 @@ func dataSourceNetworkInterface() *schema.Resource {
 }
 
 func dataSourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).Instances()
+	computeClient := meta.(*OPCClient).computeClient.Instances()
 
 	// Get required attributes
 	instance_name := d.Get("instance_name").(string)

--- a/opc/data_source_virtual_nic.go
+++ b/opc/data_source_virtual_nic.go
@@ -44,7 +44,7 @@ func dataSourceVNIC() *schema.Resource {
 }
 
 func dataSourceVNICRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).VirtNICs()
+	computeClient := meta.(*OPCClient).computeClient.VirtNICs()
 
 	name := d.Get("name").(string)
 

--- a/opc/import_storage_container_test.go
+++ b/opc/import_storage_container_test.go
@@ -1,0 +1,34 @@
+package opc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOPCStorageContainer_importBasic(t *testing.T) {
+	resourceName := "opc_storage_container.test"
+
+	rInt := acctest.RandInt()
+	config := fmt.Sprintf(testAccOPCStorageContainerBasic, rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -49,6 +49,13 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("OPC_INSECURE", false),
 				Description: "Skip TLS Verification for self-signed certificates. Should only be used if absolutely required.",
 			},
+
+			"storage": {
+				Type: schema.TypeBool,
+				Optional: true,
+				DefaultFunc: schema.EnvDefaultFunc("OPC_STORAGE", false),
+				Description: "Determines whether Terraform will authenticate with the storage api."
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -81,6 +88,7 @@ func Provider() terraform.ResourceProvider {
 			"opc_compute_ip_address_prefix_set":   resourceOPCIPAddressPrefixSet(),
 			"opc_compute_ip_address_association":  resourceOPCIPAddressAssociation(),
 			"opc_compute_snapshot":                resourceOPCSnapshot(),
+			"opc_storage_container":               resourceOPCStorageContainer(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -95,6 +103,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Endpoint:       d.Get("endpoint").(string),
 		MaxRetries:     d.Get("max_retries").(int),
 		Insecure:       d.Get("insecure").(bool),
+		Storage:        d.Get("storage").(bool),
 	}
 
 	return config.Client()

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -51,10 +51,10 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"storage": {
-				Type: schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OPC_STORAGE", false),
-				Description: "Determines whether Terraform will authenticate with the storage api."
+				Description: "Determines whether Terraform will authenticate with the storage api.",
 			},
 		},
 

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -50,11 +50,11 @@ func Provider() terraform.ResourceProvider {
 				Description: "Skip TLS Verification for self-signed certificates. Should only be used if absolutely required.",
 			},
 
-			"storage": {
-				Type:        schema.TypeBool,
+			"storage_endpoint": {
+				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OPC_STORAGE", false),
-				Description: "Determines whether Terraform will authenticate with the storage api.",
+				DefaultFunc: schema.EnvDefaultFunc("OPC_STORAGE_ENDPOINT", nil),
+				Description: "The HTTP endpoint for Oracle Storage operations.",
 			},
 		},
 
@@ -97,13 +97,13 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		User:           d.Get("user").(string),
-		Password:       d.Get("password").(string),
-		IdentityDomain: d.Get("identity_domain").(string),
-		Endpoint:       d.Get("endpoint").(string),
-		MaxRetries:     d.Get("max_retries").(int),
-		Insecure:       d.Get("insecure").(bool),
-		Storage:        d.Get("storage").(bool),
+		User:            d.Get("user").(string),
+		Password:        d.Get("password").(string),
+		IdentityDomain:  d.Get("identity_domain").(string),
+		Endpoint:        d.Get("endpoint").(string),
+		MaxRetries:      d.Get("max_retries").(int),
+		Insecure:        d.Get("insecure").(bool),
+		StorageEndpoint: d.Get("storage_endpoint").(string),
 	}
 
 	return config.Client()

--- a/opc/provider_test.go
+++ b/opc/provider_test.go
@@ -53,7 +53,7 @@ func opcResourceCheck(resourceName string, f func(checker *OPCResourceState) err
 		}
 
 		state := &OPCResourceState{
-			ComputeClient: testAccProvider.Meta().(*compute.ComputeClient),
+			ComputeClient: testAccProvider.Meta().(*OPCClient).computeClient,
 			InstanceState: rs.Primary,
 		}
 

--- a/opc/provider_test.go
+++ b/opc/provider_test.go
@@ -32,7 +32,7 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	required := []string{"OPC_USERNAME", "OPC_PASSWORD", "OPC_IDENTITY_DOMAIN", "OPC_ENDPOINT", "OPC_STORAGE"}
+	required := []string{"OPC_USERNAME", "OPC_PASSWORD", "OPC_IDENTITY_DOMAIN", "OPC_ENDPOINT", "OPC_STORAGE_ENDPOINT"}
 	for _, prop := range required {
 		if os.Getenv(prop) == "" {
 			t.Fatalf("%s must be set for acceptance test", prop)

--- a/opc/provider_test.go
+++ b/opc/provider_test.go
@@ -32,7 +32,7 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	required := []string{"OPC_USERNAME", "OPC_PASSWORD", "OPC_IDENTITY_DOMAIN", "OPC_ENDPOINT"}
+	required := []string{"OPC_USERNAME", "OPC_PASSWORD", "OPC_IDENTITY_DOMAIN", "OPC_ENDPOINT", "OPC_STORAGE"}
 	for _, prop := range required {
 		if os.Getenv(prop) == "" {
 			t.Fatalf("%s must be set for acceptance test", prop)

--- a/opc/resource_acl.go
+++ b/opc/resource_acl.go
@@ -53,7 +53,7 @@ func resourceOPCACLCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Print("[DEBUG] Creating acl")
 
-	client := meta.(*compute.ComputeClient).ACLs()
+	client := meta.(*OPCClient).computeClient.ACLs()
 	input := compute.CreateACLInput{
 		Name:    d.Get("name").(string),
 		Enabled: d.Get("enabled").(bool),
@@ -79,7 +79,7 @@ func resourceOPCACLCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceOPCACLRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	computeClient := meta.(*compute.ComputeClient).ACLs()
+	computeClient := meta.(*OPCClient).computeClient.ACLs()
 
 	log.Printf("[DEBUG] Reading state of ip reservation %s", d.Id())
 	getInput := compute.GetACLInput{
@@ -117,7 +117,7 @@ func resourceOPCACLUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Print("[DEBUG] Updating acl")
 
-	client := meta.(*compute.ComputeClient).ACLs()
+	client := meta.(*OPCClient).computeClient.ACLs()
 	input := compute.UpdateACLInput{
 		Name:    d.Get("name").(string),
 		Enabled: d.Get("enabled").(bool),
@@ -143,7 +143,7 @@ func resourceOPCACLUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceOPCACLDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	client := meta.(*compute.ComputeClient).ACLs()
+	client := meta.(*OPCClient).computeClient.ACLs()
 	name := d.Id()
 
 	log.Printf("[DEBUG] Deleting ACL: %v", name)

--- a/opc/resource_acl_test.go
+++ b/opc/resource_acl_test.go
@@ -54,7 +54,7 @@ func TestAccOPCACL_Update(t *testing.T) {
 }
 
 func testAccCheckACLExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).ACLs()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.ACLs()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_acl" {
@@ -73,7 +73,7 @@ func testAccCheckACLExists(s *terraform.State) error {
 }
 
 func testAccCheckACLDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).ACLs()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.ACLs()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_acl" {

--- a/opc/resource_image_list.go
+++ b/opc/resource_image_list.go
@@ -35,7 +35,7 @@ func resourceOPCImageList() *schema.Resource {
 }
 
 func resourceOPCImageListCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).ImageList()
+	client := meta.(*OPCClient).computeClient.ImageList()
 
 	name := d.Get("name").(string)
 
@@ -56,7 +56,7 @@ func resourceOPCImageListCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceOPCImageListUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).ImageList()
+	client := meta.(*OPCClient).computeClient.ImageList()
 
 	name := d.Id()
 
@@ -75,7 +75,7 @@ func resourceOPCImageListUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceOPCImageListRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).ImageList()
+	client := meta.(*OPCClient).computeClient.ImageList()
 
 	input := &compute.GetImageListInput{
 		Name: d.Id(),
@@ -99,7 +99,7 @@ func resourceOPCImageListRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCImageListDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).ImageList()
+	client := meta.(*OPCClient).computeClient.ImageList()
 
 	deleteInput := &compute.DeleteImageListInput{
 		Name: d.Id(),

--- a/opc/resource_image_list_entry.go
+++ b/opc/resource_image_list_entry.go
@@ -53,7 +53,7 @@ func resourceOPCImageListEntry() *schema.Resource {
 }
 
 func resourceOPCImageListEntryCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).ImageListEntries()
+	client := meta.(*OPCClient).computeClient.ImageListEntries()
 
 	name := d.Get("name").(string)
 	machineImages := expandOPCImageListEntryMachineImages(d)
@@ -86,7 +86,7 @@ func resourceOPCImageListEntryCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceOPCImageListEntryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).ImageListEntries()
+	client := meta.(*OPCClient).computeClient.ImageListEntries()
 
 	name, version, err := parseOPCImageListEntryID(d.Id())
 	if err != nil {
@@ -123,7 +123,7 @@ func resourceOPCImageListEntryRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCImageListEntryDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).ImageListEntries()
+	client := meta.(*OPCClient).computeClient.ImageListEntries()
 
 	name, version, err := parseOPCImageListEntryID(d.Id())
 	if err != nil {

--- a/opc/resource_image_list_entry_test.go
+++ b/opc/resource_image_list_entry_test.go
@@ -62,7 +62,7 @@ func TestAccOPCImageListEntry_CompleteExpanded(t *testing.T) {
 }
 
 func testAccCheckImageListEntryExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).ImageListEntries()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.ImageListEntries()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_image_list_entry" {
@@ -88,7 +88,7 @@ func testAccCheckImageListEntryExists(s *terraform.State) error {
 }
 
 func testAccCheckImageListEntryDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).ImageListEntries()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.ImageListEntries()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_image_list_entry" {

--- a/opc/resource_image_list_test.go
+++ b/opc/resource_image_list_test.go
@@ -45,7 +45,7 @@ func TestAccOPCImageList_Complete(t *testing.T) {
 }
 
 func testAccCheckImageListExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).ImageList()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.ImageList()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_image_list" {
@@ -64,7 +64,7 @@ func testAccCheckImageListExists(s *terraform.State) error {
 }
 
 func testAccCheckImageListDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).ImageList()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.ImageList()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_image_list" {

--- a/opc/resource_instance.go
+++ b/opc/resource_instance.go
@@ -363,7 +363,7 @@ func resourceInstance() *schema.Resource {
 }
 
 func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).Instances()
+	client := meta.(*OPCClient).computeClient.Instances()
 
 	// Get Required Attributes
 	input := &compute.CreateInstanceInput{
@@ -435,7 +435,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).Instances()
+	computeClient := meta.(*OPCClient).computeClient.Instances()
 
 	name := d.Get("name").(string)
 
@@ -549,7 +549,7 @@ func updateInstanceAttributes(d *schema.ResourceData, instance *compute.Instance
 }
 
 func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).Instances()
+	client := meta.(*OPCClient).computeClient.Instances()
 
 	name := d.Get("name").(string)
 
@@ -579,7 +579,7 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).Instances()
+	client := meta.(*OPCClient).computeClient.Instances()
 
 	name := d.Get("name").(string)
 

--- a/opc/resource_instance_test.go
+++ b/opc/resource_instance_test.go
@@ -240,7 +240,7 @@ func TestAccOPCInstance_Restart(t *testing.T) {
 }
 
 func testAccOPCCheckInstanceExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).Instances()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.Instances()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_instance" {
@@ -261,7 +261,7 @@ func testAccOPCCheckInstanceExists(s *terraform.State) error {
 }
 
 func testAccOPCCheckInstanceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).Instances()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.Instances()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_instance" {

--- a/opc/resource_ip_address_association.go
+++ b/opc/resource_ip_address_association.go
@@ -46,7 +46,7 @@ func resourceOPCIPAddressAssociation() *schema.Resource {
 }
 
 func resourceOPCIPAddressAssociationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAddressAssociations()
+	client := meta.(*OPCClient).computeClient.IPAddressAssociations()
 
 	input := compute.CreateIPAddressAssociationInput{
 		Name: d.Get("name").(string),
@@ -79,7 +79,7 @@ func resourceOPCIPAddressAssociationCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceOPCIPAddressAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).IPAddressAssociations()
+	computeClient := meta.(*OPCClient).computeClient.IPAddressAssociations()
 	name := d.Id()
 
 	getInput := compute.GetIPAddressAssociationInput{
@@ -111,7 +111,7 @@ func resourceOPCIPAddressAssociationRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceOPCIPAddressAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAddressAssociations()
+	client := meta.(*OPCClient).computeClient.IPAddressAssociations()
 
 	input := compute.UpdateIPAddressAssociationInput{
 		Name: d.Get("name").(string),
@@ -144,7 +144,7 @@ func resourceOPCIPAddressAssociationUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceOPCIPAddressAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAddressAssociations()
+	client := meta.(*OPCClient).computeClient.IPAddressAssociations()
 	name := d.Id()
 
 	input := compute.DeleteIPAddressAssociationInput{

--- a/opc/resource_ip_address_association_test.go
+++ b/opc/resource_ip_address_association_test.go
@@ -60,7 +60,7 @@ func TestAccOPCIPAddressAssociation_Full(t *testing.T) {
 }
 
 func testAccCheckIPAddressAssociationExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPAddressAssociations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPAddressAssociations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_address_association" {
@@ -79,7 +79,7 @@ func testAccCheckIPAddressAssociationExists(s *terraform.State) error {
 }
 
 func testAccCheckIPAddressAssociationDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPAddressAssociations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPAddressAssociations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_address_association" {

--- a/opc/resource_ip_address_prefix_set.go
+++ b/opc/resource_ip_address_prefix_set.go
@@ -47,7 +47,7 @@ func resourceOPCIPAddressPrefixSet() *schema.Resource {
 }
 
 func resourceOPCIPAddressPrefixSetCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAddressPrefixSets()
+	client := meta.(*OPCClient).computeClient.IPAddressPrefixSets()
 
 	input := compute.CreateIPAddressPrefixSetInput{
 		Name: d.Get("name").(string),
@@ -77,7 +77,7 @@ func resourceOPCIPAddressPrefixSetCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceOPCIPAddressPrefixSetRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).IPAddressPrefixSets()
+	computeClient := meta.(*OPCClient).computeClient.IPAddressPrefixSets()
 
 	input := compute.GetIPAddressPrefixSetInput{
 		Name: d.Id(),
@@ -111,7 +111,7 @@ func resourceOPCIPAddressPrefixSetRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceOPCIPAddressPrefixSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAddressPrefixSets()
+	client := meta.(*OPCClient).computeClient.IPAddressPrefixSets()
 
 	input := compute.UpdateIPAddressPrefixSetInput{
 		Name: d.Get("name").(string),
@@ -141,7 +141,7 @@ func resourceOPCIPAddressPrefixSetUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceOPCIPAddressPrefixSetDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAddressPrefixSets()
+	client := meta.(*OPCClient).computeClient.IPAddressPrefixSets()
 	name := d.Id()
 
 	input := compute.DeleteIPAddressPrefixSetInput{

--- a/opc/resource_ip_address_prefix_set_test.go
+++ b/opc/resource_ip_address_prefix_set_test.go
@@ -42,7 +42,7 @@ func TestAccOPCIPAddressPrefixSet_Basic(t *testing.T) {
 }
 
 func testAccCheckIPAddressPrefixSetExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPAddressPrefixSets()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPAddressPrefixSets()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_address_prefix_set" {
@@ -61,7 +61,7 @@ func testAccCheckIPAddressPrefixSetExists(s *terraform.State) error {
 }
 
 func testAccCheckIPAddressPrefixSetDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPAddressPrefixSets()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPAddressPrefixSets()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_address_prefix_set" {

--- a/opc/resource_ip_address_reservation.go
+++ b/opc/resource_ip_address_reservation.go
@@ -52,7 +52,7 @@ func resourceOPCIPAddressReservation() *schema.Resource {
 }
 
 func resourceOPCIPAddressReservationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAddressReservations()
+	client := meta.(*OPCClient).computeClient.IPAddressReservations()
 
 	input := compute.CreateIPAddressReservationInput{
 		Name:          d.Get("name").(string),
@@ -75,7 +75,7 @@ func resourceOPCIPAddressReservationCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceOPCIPAddressReservationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).IPAddressReservations()
+	computeClient := meta.(*OPCClient).computeClient.IPAddressReservations()
 
 	input := compute.GetIPAddressReservationInput{
 		Name: d.Id(),
@@ -109,7 +109,7 @@ func resourceOPCIPAddressReservationRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceOPCIPAddressReservationUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAddressReservations()
+	client := meta.(*OPCClient).computeClient.IPAddressReservations()
 
 	input := compute.UpdateIPAddressReservationInput{
 		Name:          d.Get("name").(string),
@@ -132,7 +132,7 @@ func resourceOPCIPAddressReservationUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceOPCIPAddressReservationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAddressReservations()
+	client := meta.(*OPCClient).computeClient.IPAddressReservations()
 	name := d.Id()
 
 	input := compute.DeleteIPAddressReservationInput{

--- a/opc/resource_ip_address_reservation_test.go
+++ b/opc/resource_ip_address_reservation_test.go
@@ -32,7 +32,7 @@ func TestAccOPCIPAddressReservation_Basic(t *testing.T) {
 }
 
 func testAccOPCCheckIPAddressReservationExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPAddressReservations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPAddressReservations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_address_reservation" {
@@ -50,7 +50,7 @@ func testAccOPCCheckIPAddressReservationExists(s *terraform.State) error {
 	return nil
 }
 func testAccOPCCheckIPAddressReservationDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPAddressReservations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPAddressReservations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_address_reservation" {

--- a/opc/resource_ip_association.go
+++ b/opc/resource_ip_association.go
@@ -43,7 +43,7 @@ func resourceOPCIPAssociationCreate(d *schema.ResourceData, meta interface{}) er
 	vCable := d.Get("vcable").(string)
 	parentPool := d.Get("parent_pool").(string)
 
-	client := meta.(*compute.ComputeClient).IPAssociations()
+	client := meta.(*OPCClient).computeClient.IPAssociations()
 	input := compute.CreateIPAssociationInput{
 		ParentPool: parentPool,
 		VCable:     vCable,
@@ -59,7 +59,7 @@ func resourceOPCIPAssociationCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceOPCIPAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).IPAssociations()
+	computeClient := meta.(*OPCClient).computeClient.IPAssociations()
 
 	name := d.Id()
 	input := compute.GetIPAssociationInput{
@@ -89,7 +89,7 @@ func resourceOPCIPAssociationRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceOPCIPAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPAssociations()
+	client := meta.(*OPCClient).computeClient.IPAssociations()
 
 	name := d.Id()
 	input := compute.DeleteIPAssociationInput{

--- a/opc/resource_ip_association_test.go
+++ b/opc/resource_ip_association_test.go
@@ -30,7 +30,7 @@ func TestAccOPCIPAssociation_Basic(t *testing.T) {
 }
 
 func testAccOPCCheckIPAssociationExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPAssociations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPAssociations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_association" {
@@ -49,7 +49,7 @@ func testAccOPCCheckIPAssociationExists(s *terraform.State) error {
 }
 
 func testAccOPCCheckIPAssociationDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPAssociations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPAssociations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_association" {

--- a/opc/resource_ip_network.go
+++ b/opc/resource_ip_network.go
@@ -57,7 +57,7 @@ func resourceOPCIPNetwork() *schema.Resource {
 }
 
 func resourceOPCIPNetworkCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPNetworks()
+	client := meta.(*OPCClient).computeClient.IPNetworks()
 
 	// Get required attributes
 	name := d.Get("name").(string)
@@ -96,7 +96,7 @@ func resourceOPCIPNetworkCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceOPCIPNetworkRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).IPNetworks()
+	computeClient := meta.(*OPCClient).computeClient.IPNetworks()
 
 	name := d.Id()
 	input := &compute.GetIPNetworkInput{
@@ -130,7 +130,7 @@ func resourceOPCIPNetworkRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCIPNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPNetworks()
+	client := meta.(*OPCClient).computeClient.IPNetworks()
 
 	// Get required attributes
 	name := d.Get("name").(string)
@@ -171,7 +171,7 @@ func resourceOPCIPNetworkUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceOPCIPNetworkDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPNetworks()
+	client := meta.(*OPCClient).computeClient.IPNetworks()
 
 	name := d.Id()
 	input := &compute.DeleteIPNetworkInput{

--- a/opc/resource_ip_network_exchange.go
+++ b/opc/resource_ip_network_exchange.go
@@ -39,7 +39,7 @@ func resourceOPCIPNetworkExchange() *schema.Resource {
 }
 
 func resourceOPCIPNetworkExchangeCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPNetworkExchanges()
+	client := meta.(*OPCClient).computeClient.IPNetworkExchanges()
 	input := compute.CreateIPNetworkExchangeInput{
 		Name: d.Get("name").(string),
 	}
@@ -64,7 +64,7 @@ func resourceOPCIPNetworkExchangeCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceOPCIPNetworkExchangeRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).IPNetworkExchanges()
+	computeClient := meta.(*OPCClient).computeClient.IPNetworkExchanges()
 
 	log.Printf("[DEBUG] Reading state of IP Network Exchange %s", d.Id())
 	input := compute.GetIPNetworkExchangeInput{
@@ -98,7 +98,7 @@ func resourceOPCIPNetworkExchangeRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceOPCIPNetworkExchangeDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).IPNetworkExchanges()
+	client := meta.(*OPCClient).computeClient.IPNetworkExchanges()
 	name := d.Id()
 
 	log.Printf("[DEBUG] Deleting IP Network Exchange '%s'", name)

--- a/opc/resource_ip_network_exchange_test.go
+++ b/opc/resource_ip_network_exchange_test.go
@@ -28,7 +28,7 @@ func TestAccOPCIPNetworkExchange_Basic(t *testing.T) {
 }
 
 func testAccCheckIPNetworkExchangeExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPNetworkExchanges()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPNetworkExchanges()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_network_exchange" {
@@ -47,7 +47,7 @@ func testAccCheckIPNetworkExchangeExists(s *terraform.State) error {
 }
 
 func testAccCheckIPNetworkExchangeDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPNetworkExchanges()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPNetworkExchanges()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_network_exchange" {

--- a/opc/resource_ip_reservation.go
+++ b/opc/resource_ip_reservation.go
@@ -65,7 +65,7 @@ func resourceOPCIPReservationCreate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Creating ip reservation from parent_pool %s with tags=%s",
 		reservation.ParentPool, reservation.Tags)
 
-	client := meta.(*compute.ComputeClient).IPReservations()
+	client := meta.(*OPCClient).computeClient.IPReservations()
 	info, err := client.CreateIPReservation(&reservation)
 	if err != nil {
 		return fmt.Errorf("Error creating ip reservation from parent_pool %s with tags=%s: %s",
@@ -78,7 +78,7 @@ func resourceOPCIPReservationCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceOPCIPReservationRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	computeClient := meta.(*compute.ComputeClient).IPReservations()
+	computeClient := meta.(*OPCClient).computeClient.IPReservations()
 
 	log.Printf("[DEBUG] Reading state of ip reservation %s", d.Id())
 	input := compute.GetIPReservationInput{
@@ -115,7 +115,7 @@ func resourceOPCIPReservationRead(d *schema.ResourceData, meta interface{}) erro
 
 func resourceOPCIPReservationDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	client := meta.(*compute.ComputeClient).IPReservations()
+	client := meta.(*OPCClient).computeClient.IPReservations()
 
 	log.Printf("[DEBUG] Deleting ip reservation %s", d.Id())
 

--- a/opc/resource_ip_reservation_test.go
+++ b/opc/resource_ip_reservation_test.go
@@ -49,7 +49,7 @@ func TestAccOPCIPreservation_OptionalParentPool(t *testing.T) {
 }
 
 func testAccCheckIPReservationExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPReservations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPReservations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_reservation" {
@@ -68,7 +68,7 @@ func testAccCheckIPReservationExists(s *terraform.State) error {
 }
 
 func testAccCheckIPReservationDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).IPReservations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.IPReservations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ip_reservation" {

--- a/opc/resource_route.go
+++ b/opc/resource_route.go
@@ -52,7 +52,7 @@ func resourceOPCRoute() *schema.Resource {
 }
 
 func resourceOPCRouteCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).Routes()
+	client := meta.(*OPCClient).computeClient.Routes()
 
 	// Get Required attributes
 	name := d.Get("name").(string)
@@ -94,7 +94,7 @@ func resourceOPCRouteCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCRouteRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).Routes()
+	computeClient := meta.(*OPCClient).computeClient.Routes()
 
 	name := d.Id()
 	input := &compute.GetRouteInput{
@@ -127,7 +127,7 @@ func resourceOPCRouteRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCRouteUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).Routes()
+	client := meta.(*OPCClient).computeClient.Routes()
 
 	// Get Required attributes
 	name := d.Get("name").(string)
@@ -169,7 +169,7 @@ func resourceOPCRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCRouteDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).Routes()
+	client := meta.(*OPCClient).computeClient.Routes()
 
 	name := d.Id()
 	input := &compute.DeleteRouteInput{

--- a/opc/resource_route_test.go
+++ b/opc/resource_route_test.go
@@ -125,7 +125,7 @@ resource "opc_compute_route" "test" {
 }
 
 func testAccOPCCheckRouteExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).Routes()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.Routes()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_route" {
@@ -144,7 +144,7 @@ func testAccOPCCheckRouteExists(s *terraform.State) error {
 }
 
 func testAccOPCCheckRouteDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).Routes()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.Routes()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_route" {

--- a/opc/resource_sec_rule.go
+++ b/opc/resource_sec_rule.go
@@ -57,7 +57,7 @@ func resourceOPCSecRule() *schema.Resource {
 }
 
 func resourceOPCSecRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecRules()
+	client := meta.(*OPCClient).computeClient.SecRules()
 
 	name := d.Get("name").(string)
 	sourceList := d.Get("source_list").(string)
@@ -90,7 +90,7 @@ func resourceOPCSecRuleCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSecRuleRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).SecRules()
+	computeClient := meta.(*OPCClient).computeClient.SecRules()
 
 	name := d.Id()
 
@@ -125,7 +125,7 @@ func resourceOPCSecRuleRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSecRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecRules()
+	client := meta.(*OPCClient).computeClient.SecRules()
 
 	name := d.Get("name").(string)
 	sourceList := d.Get("source_list").(string)
@@ -156,7 +156,7 @@ func resourceOPCSecRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSecRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecRules()
+	client := meta.(*OPCClient).computeClient.SecRules()
 	name := d.Id()
 
 	input := compute.DeleteSecRuleInput{

--- a/opc/resource_sec_rule_test.go
+++ b/opc/resource_sec_rule_test.go
@@ -45,7 +45,7 @@ func TestAccOPCSecRule_Complete(t *testing.T) {
 }
 
 func testAccCheckSecRuleExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecRules()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecRules()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_sec_rule" {
 			continue
@@ -63,7 +63,7 @@ func testAccCheckSecRuleExists(s *terraform.State) error {
 }
 
 func testAccCheckSecRuleDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecRules()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecRules()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_sec_rule" {

--- a/opc/resource_security_application.go
+++ b/opc/resource_security_application.go
@@ -82,7 +82,7 @@ func resourceOPCSecurityApplicationCreate(d *schema.ResourceData, meta interface
 	icmpcode := d.Get("icmpcode").(string)
 	description := d.Get("description").(string)
 
-	client := meta.(*compute.ComputeClient).SecurityApplications()
+	client := meta.(*OPCClient).computeClient.SecurityApplications()
 	input := compute.CreateSecurityApplicationInput{
 		Name:        name,
 		Description: description,
@@ -102,7 +102,7 @@ func resourceOPCSecurityApplicationCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceOPCSecurityApplicationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).SecurityApplications()
+	computeClient := meta.(*OPCClient).computeClient.SecurityApplications()
 	name := d.Id()
 
 	input := compute.GetSecurityApplicationInput{
@@ -134,7 +134,7 @@ func resourceOPCSecurityApplicationRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceOPCSecurityApplicationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityApplications()
+	client := meta.(*OPCClient).computeClient.SecurityApplications()
 	name := d.Id()
 
 	input := compute.DeleteSecurityApplicationInput{

--- a/opc/resource_security_application_test.go
+++ b/opc/resource_security_application_test.go
@@ -45,7 +45,7 @@ func TestAccOPCSecurityApplication_TCP(t *testing.T) {
 }
 
 func testAccOPCCheckSecurityApplicationExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityApplications()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityApplications()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_application" {
@@ -64,7 +64,7 @@ func testAccOPCCheckSecurityApplicationExists(s *terraform.State) error {
 }
 
 func testAccOPCCheckSecurityApplicationDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityApplications()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityApplications()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_application" {

--- a/opc/resource_security_association.go
+++ b/opc/resource_security_association.go
@@ -41,7 +41,7 @@ func resourceOPCSecurityAssociation() *schema.Resource {
 }
 
 func resourceOPCSecurityAssociationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityAssociations()
+	client := meta.(*OPCClient).computeClient.SecurityAssociations()
 
 	name := d.Get("name").(string)
 	vcable := d.Get("vcable").(string)
@@ -63,7 +63,7 @@ func resourceOPCSecurityAssociationCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceOPCSecurityAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).SecurityAssociations()
+	computeClient := meta.(*OPCClient).computeClient.SecurityAssociations()
 
 	name := d.Id()
 
@@ -94,7 +94,7 @@ func resourceOPCSecurityAssociationRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceOPCSecurityAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityAssociations()
+	client := meta.(*OPCClient).computeClient.SecurityAssociations()
 
 	name := d.Id()
 

--- a/opc/resource_security_association_test.go
+++ b/opc/resource_security_association_test.go
@@ -49,7 +49,7 @@ func TestAccOPCSecurityAssociation_Complete(t *testing.T) {
 }
 
 func testAccOPCCheckSecurityAssociationExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityAssociations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityAssociations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_association" {
@@ -68,7 +68,7 @@ func testAccOPCCheckSecurityAssociationExists(s *terraform.State) error {
 }
 
 func testAccOPCCheckSecurityAssociationDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityAssociations()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityAssociations()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_association" {

--- a/opc/resource_security_ip_list.go
+++ b/opc/resource_security_ip_list.go
@@ -40,7 +40,7 @@ func resourceOPCSecurityIPList() *schema.Resource {
 
 func resourceOPCSecurityIPListCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	client := meta.(*compute.ComputeClient).SecurityIPLists()
+	client := meta.(*OPCClient).computeClient.SecurityIPLists()
 
 	ipEntries := d.Get("ip_entries").([]interface{})
 	ipEntryStrings := []string{}
@@ -68,7 +68,7 @@ func resourceOPCSecurityIPListCreate(d *schema.ResourceData, meta interface{}) e
 
 func resourceOPCSecurityIPListRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	computeClient := meta.(*compute.ComputeClient).SecurityIPLists()
+	computeClient := meta.(*OPCClient).computeClient.SecurityIPLists()
 	name := d.Id()
 
 	log.Printf("[DEBUG] Reading state of security IP list %s", name)
@@ -101,7 +101,7 @@ func resourceOPCSecurityIPListRead(d *schema.ResourceData, meta interface{}) err
 func resourceOPCSecurityIPListUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
 
-	client := meta.(*compute.ComputeClient).SecurityIPLists()
+	client := meta.(*OPCClient).computeClient.SecurityIPLists()
 
 	ipEntries := d.Get("ip_entries").([]interface{})
 	ipEntryStrings := []string{}
@@ -128,7 +128,7 @@ func resourceOPCSecurityIPListUpdate(d *schema.ResourceData, meta interface{}) e
 
 func resourceOPCSecurityIPListDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	client := meta.(*compute.ComputeClient).SecurityIPLists()
+	client := meta.(*OPCClient).computeClient.SecurityIPLists()
 	name := d.Id()
 
 	log.Printf("[DEBUG] Deleting security IP list %s", name)

--- a/opc/resource_security_ip_list_test.go
+++ b/opc/resource_security_ip_list_test.go
@@ -64,7 +64,7 @@ func TestAccOPCSecurityIPList_Updated(t *testing.T) {
 }
 
 func testAccCheckSecurityIPListExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityIPLists()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityIPLists()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_ip_list" {
@@ -83,7 +83,7 @@ func testAccCheckSecurityIPListExists(s *terraform.State) error {
 }
 
 func testAccCheckSecurityIPListDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityIPLists()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityIPLists()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_ip_list" {

--- a/opc/resource_security_list.go
+++ b/opc/resource_security_list.go
@@ -62,7 +62,7 @@ func resourceOPCSecurityListCreate(d *schema.ResourceData, meta interface{}) err
 	policy := d.Get("policy").(string)
 	outboundCIDRPolicy := d.Get("outbound_cidr_policy").(string)
 
-	client := meta.(*compute.ComputeClient).SecurityLists()
+	client := meta.(*OPCClient).computeClient.SecurityLists()
 	input := compute.CreateSecurityListInput{
 		Name:               name,
 		Description:        description,
@@ -80,7 +80,7 @@ func resourceOPCSecurityListCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCSecurityListUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityLists()
+	client := meta.(*OPCClient).computeClient.SecurityLists()
 
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
@@ -102,7 +102,7 @@ func resourceOPCSecurityListUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCSecurityListRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).SecurityLists()
+	computeClient := meta.(*OPCClient).computeClient.SecurityLists()
 
 	name := d.Id()
 
@@ -134,7 +134,7 @@ func resourceOPCSecurityListRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceOPCSecurityListDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityLists()
+	client := meta.(*OPCClient).computeClient.SecurityLists()
 
 	name := d.Id()
 	input := compute.DeleteSecurityListInput{

--- a/opc/resource_security_list_test.go
+++ b/opc/resource_security_list_test.go
@@ -45,7 +45,7 @@ func TestAccOPCSecurityList_complete(t *testing.T) {
 }
 
 func testAccCheckSecurityListExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityLists()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityLists()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_list" {
@@ -64,7 +64,7 @@ func testAccCheckSecurityListExists(s *terraform.State) error {
 }
 
 func testAccCheckSecurityListDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityLists()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityLists()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_list" {

--- a/opc/resource_security_protocol.go
+++ b/opc/resource_security_protocol.go
@@ -55,7 +55,7 @@ func resourceOPCSecurityProtocol() *schema.Resource {
 }
 
 func resourceOPCSecurityProtocolCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityProtocols()
+	client := meta.(*OPCClient).computeClient.SecurityProtocols()
 	input := compute.CreateSecurityProtocolInput{
 		Name:       d.Get("name").(string),
 		IPProtocol: d.Get("ip_protocol").(string),
@@ -87,7 +87,7 @@ func resourceOPCSecurityProtocolCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceOPCSecurityProtocolRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).SecurityProtocols()
+	computeClient := meta.(*OPCClient).computeClient.SecurityProtocols()
 
 	input := compute.GetSecurityProtocolInput{
 		Name: d.Id(),
@@ -124,7 +124,7 @@ func resourceOPCSecurityProtocolRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceOPCSecurityProtocolUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityProtocols()
+	client := meta.(*OPCClient).computeClient.SecurityProtocols()
 	input := compute.UpdateSecurityProtocolInput{
 		Name:       d.Get("name").(string),
 		IPProtocol: d.Get("ip_protocol").(string),
@@ -155,7 +155,7 @@ func resourceOPCSecurityProtocolUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceOPCSecurityProtocolDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityProtocols()
+	client := meta.(*OPCClient).computeClient.SecurityProtocols()
 	name := d.Id()
 
 	input := compute.DeleteSecurityProtocolInput{

--- a/opc/resource_security_protocol_test.go
+++ b/opc/resource_security_protocol_test.go
@@ -89,7 +89,7 @@ func TestAccOPCSecurityProtocol_Update(t *testing.T) {
 }
 
 func testAccCheckSecurityProtocolExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityProtocols()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityProtocols()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_protocol" {
@@ -108,7 +108,7 @@ func testAccCheckSecurityProtocolExists(s *terraform.State) error {
 }
 
 func testAccCheckSecurityProtocolDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityProtocols()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityProtocols()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_protocol" {

--- a/opc/resource_security_rule.go
+++ b/opc/resource_security_rule.go
@@ -74,7 +74,7 @@ func resourceOPCSecurityRule() *schema.Resource {
 }
 
 func resourceOPCSecurityRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityRules()
+	client := meta.(*OPCClient).computeClient.SecurityRules()
 	input := compute.CreateSecurityRuleInput{
 		Name:          d.Get("name").(string),
 		FlowDirection: d.Get("flow_direction").(string),
@@ -127,7 +127,7 @@ func resourceOPCSecurityRuleCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCSecurityRuleRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).SecurityRules()
+	computeClient := meta.(*OPCClient).computeClient.SecurityRules()
 
 	input := compute.GetSecurityRuleInput{
 		Name: d.Id(),
@@ -173,7 +173,7 @@ func resourceOPCSecurityRuleRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceOPCSecurityRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityRules()
+	client := meta.(*OPCClient).computeClient.SecurityRules()
 	input := compute.UpdateSecurityRuleInput{
 		Name:          d.Get("name").(string),
 		FlowDirection: d.Get("flow_direction").(string),
@@ -225,7 +225,7 @@ func resourceOPCSecurityRuleUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCSecurityRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SecurityRules()
+	client := meta.(*OPCClient).computeClient.SecurityRules()
 	name := d.Id()
 
 	input := compute.DeleteSecurityRuleInput{

--- a/opc/resource_security_rule_test.go
+++ b/opc/resource_security_rule_test.go
@@ -64,7 +64,7 @@ func TestAccOPCSecurityRule_Full(t *testing.T) {
 }
 
 func testAccCheckSecurityRuleExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityRules()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityRules()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_sec_rule" {
 			continue
@@ -82,7 +82,7 @@ func testAccCheckSecurityRuleExists(s *terraform.State) error {
 }
 
 func testAccCheckSecurityRuleDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SecurityRules()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SecurityRules()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_security_rule" {

--- a/opc/resource_snapshot.go
+++ b/opc/resource_snapshot.go
@@ -50,7 +50,7 @@ func resourceOPCSnapshot() *schema.Resource {
 }
 
 func resourceOPCSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).Snapshots()
+	client := meta.(*OPCClient).computeClient.Snapshots()
 
 	instance := d.Get("instance").(string)
 
@@ -77,7 +77,7 @@ func resourceOPCSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSnapshotRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).Snapshots()
+	computeClient := meta.(*OPCClient).computeClient.Snapshots()
 
 	name := d.Id()
 
@@ -105,8 +105,8 @@ func resourceOPCSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).Snapshots()
-	machineImageClient := meta.(*compute.ComputeClient).MachineImages()
+	computeClient := meta.(*OPCClient).computeClient.Snapshots()
+	machineImageClient := meta.(*OPCClient).computeClient.MachineImages()
 	name := d.Id()
 
 	getInput := compute.GetSnapshotInput{

--- a/opc/resource_snapshot_test.go
+++ b/opc/resource_snapshot_test.go
@@ -49,7 +49,7 @@ func TestAccOPCSnapshot_MachineImage(t *testing.T) {
 }
 
 func testAccCheckSnapshotExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).Snapshots()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.Snapshots()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_snapshot" {
 			continue
@@ -67,7 +67,7 @@ func testAccCheckSnapshotExists(s *terraform.State) error {
 }
 
 func testAccCheckSnapshotDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).Snapshots()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.Snapshots()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_snapshot" {

--- a/opc/resource_ssh_key.go
+++ b/opc/resource_ssh_key.go
@@ -40,7 +40,7 @@ func resourceOPCSSHKey() *schema.Resource {
 }
 
 func resourceOPCSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SSHKeys()
+	client := meta.(*OPCClient).computeClient.SSHKeys()
 
 	name := d.Get("name").(string)
 	key := d.Get("key").(string)
@@ -63,7 +63,7 @@ func resourceOPCSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SSHKeys()
+	client := meta.(*OPCClient).computeClient.SSHKeys()
 
 	name := d.Get("name").(string)
 	key := d.Get("key").(string)
@@ -84,7 +84,7 @@ func resourceOPCSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).SSHKeys()
+	computeClient := meta.(*OPCClient).computeClient.SSHKeys()
 	name := d.Id()
 
 	input := compute.GetSSHKeyInput{
@@ -113,7 +113,7 @@ func resourceOPCSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).SSHKeys()
+	client := meta.(*OPCClient).computeClient.SSHKeys()
 	name := d.Id()
 
 	input := compute.DeleteSSHKeyInput{

--- a/opc/resource_ssh_key_test.go
+++ b/opc/resource_ssh_key_test.go
@@ -90,7 +90,7 @@ func TestAccOPCSSHKey_disable(t *testing.T) {
 }
 
 func testAccOPCCheckSSHKeyExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SSHKeys()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SSHKeys()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ssh_key" {
@@ -109,7 +109,7 @@ func testAccOPCCheckSSHKeyExists(s *terraform.State) error {
 }
 
 func testAccOPCCheckSSHKeyDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).SSHKeys()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.SSHKeys()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_ssh_key" {

--- a/opc/resource_storage_container.go
+++ b/opc/resource_storage_container.go
@@ -59,6 +59,9 @@ func resourceOPCStorageContainer() *schema.Resource {
 
 func resourceOPCStorageContainerCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*OPCClient).storageClient
+	if client == nil {
+		return fmt.Errorf("Storage Client is not initialized. Make sure to use `storage_endpoint` variable or `OPC_STORAGE_ENDPOINT env variable`")
+	}
 
 	input := storage.CreateContainerInput{
 		Name: d.Get("name").(string),
@@ -94,6 +97,9 @@ func resourceOPCStorageContainerCreate(d *schema.ResourceData, meta interface{})
 
 func resourceOPCStorageContainerRead(d *schema.ResourceData, meta interface{}) error {
 	storageClient := meta.(*OPCClient).storageClient
+	if storageClient == nil {
+		return fmt.Errorf("Storage Client is not initialized. Make sure to use `storage_endpoint` variable or `OPC_STORAGE_ENDPOINT env variable`")
+	}
 
 	name := d.Id()
 	input := storage.GetContainerInput{
@@ -134,6 +140,9 @@ func resourceOPCStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceOPCStorageContainerDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*OPCClient).storageClient
+	if client == nil {
+		return fmt.Errorf("Storage Client is not initialized. Make sure to use `storage_endpoint` variable or `OPC_STORAGE_ENDPOINT env variable`")
+	}
 
 	name := d.Id()
 	input := storage.DeleteContainerInput{
@@ -148,6 +157,9 @@ func resourceOPCStorageContainerDelete(d *schema.ResourceData, meta interface{})
 
 func resourceOPCStorageContainerUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*OPCClient).storageClient
+	if client == nil {
+		return fmt.Errorf("Storage Client is not initialized. Make sure to use `storage_endpoint` variable or `OPC_STORAGE_ENDPOINT env variable`")
+	}
 
 	input := storage.UpdateContainerInput{
 		Name: d.Get("name").(string),

--- a/opc/resource_storage_container.go
+++ b/opc/resource_storage_container.go
@@ -1,0 +1,143 @@
+package opc
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-oracle-terraform/client"
+	"github.com/hashicorp/go-oracle-terraform/storage"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceOPCStorageContainer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOPCStorageContainerCreate,
+		Read:   resourceOPCStorageContainerRead,
+		Delete: resourceOPCStorageContainerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+      "read_acls": {
+        Type:     schema.TypeList,
+        Optional: true,
+        Elem:     &schema.Schema{Type: schema.TypeString},
+      },
+      "write_acls": {
+        Type:     schema.TypeList,
+        Optional: true,
+        Elem:     &schema.Schema{Type: schema.TypeString},
+      },
+      "allowed_origins": {
+        Type:     schema.TypeList,
+        Optional: true,
+        Elem:     &schema.Schema{Type: schema.TypeString},
+      },
+      "primary_key": {
+        Type: schema.TypeString,
+        Optional: true,
+      },
+      "secondary_key": {
+        Type: schema.TypeString,
+        Optional: true,
+      },
+      "max_age": {
+        Type: schema.TypeInt,
+        Optional: true,
+      },
+		},
+	}
+}
+
+func resourceOPCStorageContainerCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*OPCClient).storageClient
+
+	input := storage.CreateContainerInput{
+		Name: d.Get("name").(string)
+	}
+  if readAcls := getStringList(d, "read_acls"); len(readAcls) > 0 {
+    input.ReadACLs = readAcls
+  }
+  if writeAcls := getStringList(d, "write_acls"); len(writeAcls) > 0 {
+    input.WriteACLs = writeAcls
+  }
+  if allowedOrigins := getStringList(d, "allowed_origins"); len(allowedOrigins) > 0 {
+    input.AllowedOrigins = allowedOrigins
+  }
+  if primaryKey, ok := d.GetOk("primary_key"); ok {
+    input.PrimaryKey = primaryKey.(string)
+  }
+  if secondaryKey, ok := d.GetOk("secondary_key"); ok {
+    input.SecondaryKey = secondaryKey.(string)
+  }
+  if maxAge, ok := d.GetOk("max_age"); ok {
+    input.MaxAge = maxAge.(int)
+  }
+
+	info, err := client.CreateContainer(&input)
+	if err != nil {
+		return fmt.Errorf("Error creating Storage Container: %s", err)
+	}
+
+	d.SetId(info.Name)
+
+	return resourceOPCStorageContainerRead(d, meta)
+}
+
+func resourceOPCStorageContainerRead(d *schema.ResourceData, meta interface{}) error {
+	storageClient := meta.(*OPCClient).storageClient
+
+	name := d.Id()
+	input := compute.GetStorageContainerInput{
+		Name: name,
+	}
+
+	result, err := storageClient.GetStorageContainer(&input)
+	if err != nil {
+		// Storage Container does not exist
+		if client.WasNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading Storage Container '%s': %s", name, err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", result.Name)
+  d.Set("primary_key", result.PrimaryKey)
+  d.Set("secondary_key", result.SecondaryKey)
+  d.Set("max_age", result.MaxAge)
+  if err := setStringList(d, "read_acls", result.ReadACLs); err != nil {
+    return err
+  }
+  if err := setStringList(d, "write_acls", result.WriteACLs); err != nil {
+    return err
+  }
+  if err := setStringList(d, "allowed_origins", result.AllowedOrigins); err != nil {
+    return err
+  }
+
+	return nil
+}
+
+func resourceOPCStorageContainerDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*OPCClient).storageClient
+
+	name := d.Id()
+	input := compute.DeleteStorageContainerInput{
+		Name: name,
+	}
+	if err := client.DeleteStorageContainer(&input); err != nil {
+		return fmt.Errorf("Error deleting Storage Container '%s': %s", name, err)
+	}
+
+	return nil
+}

--- a/opc/resource_storage_container.go
+++ b/opc/resource_storage_container.go
@@ -13,6 +13,7 @@ func resourceOPCStorageContainer() *schema.Resource {
 		Create: resourceOPCStorageContainerCreate,
 		Read:   resourceOPCStorageContainerRead,
 		Delete: resourceOPCStorageContainerDelete,
+		Update: resourceOPCStorageContainerUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -22,33 +23,36 @@ func resourceOPCStorageContainer() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-      "read_acls": {
-        Type:     schema.TypeList,
-        Optional: true,
-        Elem:     &schema.Schema{Type: schema.TypeString},
-      },
-      "write_acls": {
-        Type:     schema.TypeList,
-        Optional: true,
-        Elem:     &schema.Schema{Type: schema.TypeString},
-      },
-      "allowed_origins": {
-        Type:     schema.TypeList,
-        Optional: true,
-        Elem:     &schema.Schema{Type: schema.TypeString},
-      },
-      "primary_key": {
-        Type: schema.TypeString,
-        Optional: true,
-      },
-      "secondary_key": {
-        Type: schema.TypeString,
-        Optional: true,
-      },
-      "max_age": {
-        Type: schema.TypeInt,
-        Optional: true,
-      },
+			"read_acls": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"write_acls": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"allowed_origins": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"primary_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"secondary_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"max_age": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -57,26 +61,26 @@ func resourceOPCStorageContainerCreate(d *schema.ResourceData, meta interface{})
 	client := meta.(*OPCClient).storageClient
 
 	input := storage.CreateContainerInput{
-		Name: d.Get("name").(string)
+		Name: d.Get("name").(string),
 	}
-  if readAcls := getStringList(d, "read_acls"); len(readAcls) > 0 {
-    input.ReadACLs = readAcls
-  }
-  if writeAcls := getStringList(d, "write_acls"); len(writeAcls) > 0 {
-    input.WriteACLs = writeAcls
-  }
-  if allowedOrigins := getStringList(d, "allowed_origins"); len(allowedOrigins) > 0 {
-    input.AllowedOrigins = allowedOrigins
-  }
-  if primaryKey, ok := d.GetOk("primary_key"); ok {
-    input.PrimaryKey = primaryKey.(string)
-  }
-  if secondaryKey, ok := d.GetOk("secondary_key"); ok {
-    input.SecondaryKey = secondaryKey.(string)
-  }
-  if maxAge, ok := d.GetOk("max_age"); ok {
-    input.MaxAge = maxAge.(int)
-  }
+	if readAcls := getStringList(d, "read_acls"); len(readAcls) > 0 {
+		input.ReadACLs = readAcls
+	}
+	if writeAcls := getStringList(d, "write_acls"); len(writeAcls) > 0 {
+		input.WriteACLs = writeAcls
+	}
+	if allowedOrigins := getStringList(d, "allowed_origins"); len(allowedOrigins) > 0 {
+		input.AllowedOrigins = allowedOrigins
+	}
+	if primaryKey, ok := d.GetOk("primary_key"); ok {
+		input.PrimaryKey = primaryKey.(string)
+	}
+	if secondaryKey, ok := d.GetOk("secondary_key"); ok {
+		input.SecondaryKey = secondaryKey.(string)
+	}
+	if maxAge, ok := d.GetOk("max_age"); ok {
+		input.MaxAge = maxAge.(int)
+	}
 
 	info, err := client.CreateContainer(&input)
 	if err != nil {
@@ -92,11 +96,11 @@ func resourceOPCStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 	storageClient := meta.(*OPCClient).storageClient
 
 	name := d.Id()
-	input := compute.GetStorageContainerInput{
+	input := storage.GetContainerInput{
 		Name: name,
 	}
 
-	result, err := storageClient.GetStorageContainer(&input)
+	result, err := storageClient.GetContainer(&input)
 	if err != nil {
 		// Storage Container does not exist
 		if client.WasNotFoundError(err) {
@@ -112,18 +116,18 @@ func resourceOPCStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("name", result.Name)
-  d.Set("primary_key", result.PrimaryKey)
-  d.Set("secondary_key", result.SecondaryKey)
-  d.Set("max_age", result.MaxAge)
-  if err := setStringList(d, "read_acls", result.ReadACLs); err != nil {
-    return err
-  }
-  if err := setStringList(d, "write_acls", result.WriteACLs); err != nil {
-    return err
-  }
-  if err := setStringList(d, "allowed_origins", result.AllowedOrigins); err != nil {
-    return err
-  }
+	d.Set("primary_key", result.PrimaryKey)
+	d.Set("secondary_key", result.SecondaryKey)
+	d.Set("max_age", result.MaxAge)
+	if err := setStringList(d, "read_acls", result.ReadACLs); err != nil {
+		return err
+	}
+	if err := setStringList(d, "write_acls", result.WriteACLs); err != nil {
+		return err
+	}
+	if err := setStringList(d, "allowed_origins", result.AllowedOrigins); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -132,12 +136,47 @@ func resourceOPCStorageContainerDelete(d *schema.ResourceData, meta interface{})
 	client := meta.(*OPCClient).storageClient
 
 	name := d.Id()
-	input := compute.DeleteStorageContainerInput{
+	input := storage.DeleteContainerInput{
 		Name: name,
 	}
-	if err := client.DeleteStorageContainer(&input); err != nil {
+	if err := client.DeleteContainer(&input); err != nil {
 		return fmt.Errorf("Error deleting Storage Container '%s': %s", name, err)
 	}
 
 	return nil
+}
+
+func resourceOPCStorageContainerUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*OPCClient).storageClient
+
+	input := storage.UpdateContainerInput{
+		Name: d.Get("name").(string),
+	}
+	if readAcls := getStringList(d, "read_acls"); len(readAcls) > 0 {
+		input.ReadACLs = readAcls
+	}
+	if writeAcls := getStringList(d, "write_acls"); len(writeAcls) > 0 {
+		input.WriteACLs = writeAcls
+	}
+	if allowedOrigins := getStringList(d, "allowed_origins"); len(allowedOrigins) > 0 {
+		input.AllowedOrigins = allowedOrigins
+	}
+	if primaryKey, ok := d.GetOk("primary_key"); ok {
+		input.PrimaryKey = primaryKey.(string)
+	}
+	if secondaryKey, ok := d.GetOk("secondary_key"); ok {
+		input.SecondaryKey = secondaryKey.(string)
+	}
+	if maxAge, ok := d.GetOk("max_age"); ok {
+		input.MaxAge = maxAge.(int)
+	}
+
+	info, err := client.UpdateContainer(&input)
+	if err != nil {
+		return fmt.Errorf("Error updating Storage Container: %s", err)
+	}
+
+	d.SetId(info.Name)
+
+	return resourceOPCStorageContainerRead(d, meta)
 }

--- a/opc/resource_storage_container_test.go
+++ b/opc/resource_storage_container_test.go
@@ -1,0 +1,124 @@
+package opc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/storage"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOPCStorageContainer_Basic(t *testing.T) {
+	containerResourceName := "opc_storage_container.test"
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccOPCStorageContainerBasic, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageContainerExists,
+					resource.TestCheckResourceAttr(containerResourceName, "max_age", "50"),
+					resource.TestCheckResourceAttr(containerResourceName, "primary_key", "test-key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOPCStorageContainer_Updated(t *testing.T) {
+	containerResourceName := "opc_storage_container.test"
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccOPCStorageContainerBasic, ri)
+	config2 := fmt.Sprintf(testAccOPCStorageContainerUpdated, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageContainerExists,
+					resource.TestCheckResourceAttr(containerResourceName, "max_age", "50"),
+					resource.TestCheckResourceAttr(containerResourceName, "primary_key", "test-key"),
+					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.0", "origin-1"),
+				),
+			},
+			{
+				Config: config2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageContainerExists,
+					resource.TestCheckResourceAttr(containerResourceName, "max_age", "60"),
+					resource.TestCheckResourceAttr(containerResourceName, "primary_key", "test-key-updated"),
+					resource.TestCheckResourceAttr(containerResourceName, "secondary_key", "test-key"),
+					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.0", "origin-2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckStorageContainerExists(s *terraform.State) error {
+	client := testAccProvider.Meta().(*OPCClient).storageClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opc_storage_container" {
+			continue
+		}
+
+		input := storage.GetContainerInput{
+			Name: rs.Primary.Attributes["name"],
+		}
+		if _, err := client.GetContainer(&input); err != nil {
+			return fmt.Errorf("Error retrieving state of Storage Container %s: %s", input.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckStorageContainerDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*OPCClient).storageClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opc_storage_container" {
+			continue
+		}
+
+		input := storage.GetContainerInput{
+			Name: rs.Primary.Attributes["name"],
+		}
+		if info, err := client.GetContainer(&input); err == nil {
+			return fmt.Errorf("Storage Container %s still exists: %#v", input.Name, info)
+		}
+	}
+
+	return nil
+}
+
+const testAccOPCStorageContainerBasic = `
+resource "opc_storage_container" "test" {
+	name = "acc-storage-container-%d"
+  max_age = 50
+  primary_key = "test-key"
+	allowed_origins = ["origin-1"]
+}
+`
+
+const testAccOPCStorageContainerUpdated = `
+resource "opc_storage_container" "test" {
+	name = "acc-storage-container-%d"
+  max_age = 60
+  primary_key = "test-key-updated"
+  secondary_key = "test-key"
+	allowed_origins = ["origin-2"]
+}
+`

--- a/opc/resource_storage_container_test.go
+++ b/opc/resource_storage_container_test.go
@@ -108,19 +108,19 @@ func testAccCheckStorageContainerDestroy(s *terraform.State) error {
 
 const testAccOPCStorageContainerBasic = `
 resource "opc_storage_container" "test" {
-	name = "acc-storage-container-%d"
+  name = "acc-storage-container-%d"
   max_age = 50
   primary_key = "test-key"
-	allowed_origins = ["origin-1"]
+  allowed_origins = ["origin-1"]
 }
 `
 
 const testAccOPCStorageContainerUpdated = `
 resource "opc_storage_container" "test" {
-	name = "acc-storage-container-%d"
+  name = "acc-storage-container-%d"
   max_age = 60
   primary_key = "test-key-updated"
   secondary_key = "test-key"
-	allowed_origins = ["origin-1", "origin-2"]
+  allowed_origins = ["origin-1", "origin-2"]
 }
 `

--- a/opc/resource_storage_container_test.go
+++ b/opc/resource_storage_container_test.go
@@ -49,6 +49,7 @@ func TestAccOPCStorageContainer_Updated(t *testing.T) {
 					testAccCheckStorageContainerExists,
 					resource.TestCheckResourceAttr(containerResourceName, "max_age", "50"),
 					resource.TestCheckResourceAttr(containerResourceName, "primary_key", "test-key"),
+					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.#", "1"),
 					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.0", "origin-1"),
 				),
 			},
@@ -59,7 +60,8 @@ func TestAccOPCStorageContainer_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(containerResourceName, "max_age", "60"),
 					resource.TestCheckResourceAttr(containerResourceName, "primary_key", "test-key-updated"),
 					resource.TestCheckResourceAttr(containerResourceName, "secondary_key", "test-key"),
-					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.0", "origin-2"),
+					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.#", "2"),
+					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.1", "origin-2"),
 				),
 			},
 		},
@@ -119,6 +121,6 @@ resource "opc_storage_container" "test" {
   max_age = 60
   primary_key = "test-key-updated"
   secondary_key = "test-key"
-	allowed_origins = ["origin-2"]
+	allowed_origins = ["origin-1", "origin-2"]
 }
 `

--- a/opc/resource_storage_volume.go
+++ b/opc/resource_storage_volume.go
@@ -134,7 +134,7 @@ func resourceOPCStorageVolume() *schema.Resource {
 }
 
 func resourceOPCStorageVolumeCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).StorageVolumes()
+	client := meta.(*OPCClient).computeClient.StorageVolumes()
 
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
@@ -185,7 +185,7 @@ func resourceOPCStorageVolumeCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceOPCStorageVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).StorageVolumes()
+	client := meta.(*OPCClient).computeClient.StorageVolumes()
 
 	name := d.Id()
 	description := d.Get("description").(string)
@@ -212,7 +212,7 @@ func resourceOPCStorageVolumeUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceOPCStorageVolumeRead(d *schema.ResourceData, meta interface{}) error {
-	sv := meta.(*compute.ComputeClient).StorageVolumes()
+	sv := meta.(*OPCClient).computeClient.StorageVolumes()
 
 	name := d.Id()
 	input := compute.GetStorageVolumeInput{
@@ -261,7 +261,7 @@ func resourceOPCStorageVolumeRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceOPCStorageVolumeDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).StorageVolumes()
+	client := meta.(*OPCClient).computeClient.StorageVolumes()
 	name := d.Id()
 
 	input := compute.DeleteStorageVolumeInput{

--- a/opc/resource_storage_volume_snapshot.go
+++ b/opc/resource_storage_volume_snapshot.go
@@ -122,7 +122,7 @@ func resourceOPCStorageVolumeSnapshot() *schema.Resource {
 }
 
 func resourceOPCStorageVolumeSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).StorageVolumeSnapshots()
+	client := meta.(*OPCClient).computeClient.StorageVolumeSnapshots()
 
 	// Get required attribute
 	input := &compute.CreateStorageVolumeSnapshotInput{
@@ -163,7 +163,7 @@ func resourceOPCStorageVolumeSnapshotCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceOPCStorageVolumeSnapshotRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).StorageVolumeSnapshots()
+	computeClient := meta.(*OPCClient).computeClient.StorageVolumeSnapshots()
 
 	name := d.Id()
 	input := &compute.GetStorageVolumeSnapshotInput{
@@ -221,7 +221,7 @@ func resourceOPCStorageVolumeSnapshotRead(d *schema.ResourceData, meta interface
 }
 
 func resourceOPCStorageVolumeSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).StorageVolumeSnapshots()
+	client := meta.(*OPCClient).computeClient.StorageVolumeSnapshots()
 
 	name := d.Id()
 

--- a/opc/resource_vnic_set.go
+++ b/opc/resource_vnic_set.go
@@ -48,7 +48,7 @@ func resourceOPCVNICSet() *schema.Resource {
 }
 
 func resourceOPCVNICSetCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).VirtNICSets()
+	client := meta.(*OPCClient).computeClient.VirtNICSets()
 
 	name := d.Get("name").(string)
 	desc, descOk := d.GetOk("description")
@@ -87,7 +87,7 @@ func resourceOPCVNICSetCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCVNICSetRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*compute.ComputeClient).VirtNICSets()
+	computeClient := meta.(*OPCClient).computeClient.VirtNICSets()
 
 	name := d.Id()
 	input := &compute.GetVirtualNICSetInput{
@@ -123,7 +123,7 @@ func resourceOPCVNICSetRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCVNICSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).VirtNICSets()
+	client := meta.(*OPCClient).computeClient.VirtNICSets()
 
 	name := d.Id()
 	desc, descOk := d.GetOk("description")
@@ -161,7 +161,7 @@ func resourceOPCVNICSetUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCVNICSetDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*compute.ComputeClient).VirtNICSets()
+	client := meta.(*OPCClient).computeClient.VirtNICSets()
 
 	name := d.Id()
 	input := &compute.DeleteVirtualNICSetInput{

--- a/opc/resource_vnic_set_test.go
+++ b/opc/resource_vnic_set_test.go
@@ -53,7 +53,7 @@ func TestAccOPCVNICSet_Basic(t *testing.T) {
 }
 
 func testAccOPCCheckVNICSetExists(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).VirtNICSets()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.VirtNICSets()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_vnic_set" {
@@ -72,7 +72,7 @@ func testAccOPCCheckVNICSetExists(s *terraform.State) error {
 }
 
 func testAccOPCCheckVNICSetDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*compute.ComputeClient).VirtNICSets()
+	client := testAccProvider.Meta().(*OPCClient).computeClient.VirtNICSets()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_compute_vnic_set" {

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/authentication.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/authentication.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"fmt"
+	"time"
+)
+
+// Get a new auth token for the storage client
+func (c *StorageClient) getAuthenticationToken() error {
+	var authHeaders map[string]string
+	authHeaders = make(map[string]string)
+	authHeaders["X-Storage-User"] = c.getUserName()
+	authHeaders["X-Storage-Pass"] = *c.client.Password
+
+	rsp, err := c.executeRequest("GET", "/auth/v1.0", authHeaders)
+	if err != nil {
+		return err
+	}
+
+	authToken := rsp.Header.Get("X-Auth-Token")
+	if authToken == "" {
+		return fmt.Errorf("No authentication token found in response %#v", rsp)
+	}
+
+	c.client.DebugLogString("Successfully authenticated to IaaS Storage")
+	c.authToken = &authToken
+	c.tokenIssued = time.Now()
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/container.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/container.go
@@ -1,0 +1,187 @@
+package storage
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const CONTAINER_VERSION = "v1"
+
+// Container describes an existing Container.
+type Container struct {
+	// The name of the Container
+	Name string
+	// A container access control list (ACL) that grants read access.
+	ReadACLs []string
+	// A container access control list (ACL) that grants write access
+	WriteACLs []string
+	// The secret key value for temporary URLs.
+	PrimaryKey string
+	// The second secret key value for temporary URLs.
+	SecondaryKey string
+	// List of origins to be allowed to make cross-origin Requests.
+	AllowedOrigins []string
+	// Maximum age in seconds for the origin to hold the preflight results.
+	MaxAge int
+}
+
+// CreateContainerInput defines an Container to be created.
+type CreateContainerInput struct {
+	// The unique name for the container. The container name must be from 1 to 256 characters long and can
+	// start with any character and contain any pattern. Character set must be UTF-8. The container name
+	// cannot contain a slash (/) character because this character delimits the container and object name.
+	// For example, /account/container/object.
+	// Required
+	Name string `json:"name"`
+	// Sets a container access control list (ACL) that grants read access.
+	// Optional
+	ReadACLs []string
+	// Sets a container access control list (ACL) that grants read access.
+	// Optional
+	WriteACLs []string
+	// Sets a secret key value for temporary URLs.
+	// Optional
+	PrimaryKey string
+	// Sets a second secret key value for temporary URLs.
+	// Optional
+	SecondaryKey string
+	// Sets the list of origins allowed to make cross-origin requests.
+	// Optional
+	AllowedOrigins []string
+	// Sets the maximum age in seconds for the origin to hold the preflight results.
+	// Optional
+	MaxAge int
+}
+
+// CreateContainer creates a new Container with the given name, key and enabled flag.
+func (c *StorageClient) CreateContainer(input *CreateContainerInput) (*Container, error) {
+	headers := make(map[string]string)
+
+	input.Name = c.getQualifiedName(CONTAINER_VERSION, input.Name)
+
+	// There are default values for these that we don't want to zero out if Read and Write ACLs are not set.
+	if len(input.ReadACLs) > 0 {
+		headers["X-Container-Read"] = strings.Join(input.ReadACLs, ",")
+	}
+	if len(input.WriteACLs) > 0 {
+		headers["X-Container-Write"] = strings.Join(input.WriteACLs, ",")
+	}
+
+	headers["X-Container-Meta-Temp-URL-Key"] = input.PrimaryKey
+	headers["X-Container-Meta-Temp-URL-Key-2"] = input.SecondaryKey
+	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(input.MaxAge)
+
+	if err := c.createResource(input.Name, headers); err != nil {
+		return nil, err
+	}
+
+	getInput := GetContainerInput{
+		Name: input.Name,
+	}
+
+	return c.GetContainer(&getInput)
+}
+
+// DeleteKeyInput describes the container to delete
+type DeleteContainerInput struct {
+	// The name of the Container
+	// Required
+	Name string `json:name`
+}
+
+// DeleteContainer deletes the Container with the given name.
+func (c *StorageClient) DeleteContainer(input *DeleteContainerInput) error {
+	input.Name = c.getQualifiedName(CONTAINER_VERSION, input.Name)
+	return c.deleteResource(input.Name)
+}
+
+// GetContainerInput describes the container to get
+type GetContainerInput struct {
+	// The name of the Container
+	// Required
+	Name string `json:name`
+}
+
+// GetContainer retrieves the Container with the given name.
+func (c *StorageClient) GetContainer(input *GetContainerInput) (*Container, error) {
+	var container Container
+	input.Name = c.getQualifiedName(CONTAINER_VERSION, input.Name)
+
+	rsp, err := c.getResource(input.Name, &container)
+	if err != nil {
+		return nil, err
+	}
+	// The response doesn't come back with the name so we need to set it from the Input Name
+	container.Name = c.getUnqualifiedName(input.Name)
+	return c.success(rsp, &container)
+}
+
+// UpdateContainerInput defines an Container to be updated
+type UpdateContainerInput struct {
+	// The name of the Container
+	// Required
+	Name string `json:"name"`
+	// Updates a container access control list (ACL) that grants read access.
+	// Optional
+	ReadACLs []string
+	// Updates a container access control list (ACL) that grants write access.
+	// Optional
+	WriteACLs []string
+	// Updates the secret key value for temporary URLs.
+	// Optional
+	PrimaryKey string
+	// Update the second secret key value for temporary URLs.
+	// Optional
+	SecondaryKey string
+	// Updates the list of origins allowed to make cross-origin requests.
+	// Optional
+	AllowedOrigins []string
+	// Updates the maximum age in seconds for the origin to hold the preflight results.
+	// Optional
+	MaxAge int
+}
+
+// UpdateContainer updates the key and enabled flag of the Container with the given name.
+func (c *StorageClient) UpdateContainer(input *UpdateContainerInput) (*Container, error) {
+	headers := make(map[string]string)
+
+	// There are default values for these that we don't want to zero out if Read and Write ACLs are not set.
+	if len(input.ReadACLs) > 0 {
+		headers["X-Container-Read"] = strings.Join(input.ReadACLs, ",")
+	}
+	if len(input.WriteACLs) > 0 {
+		headers["X-Container-Write"] = strings.Join(input.WriteACLs, ",")
+	}
+
+	headers["X-Container-Meta-Temp-URL-Key"] = input.PrimaryKey
+	headers["X-Container-Meta-Temp-URL-Key-2"] = input.SecondaryKey
+	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(input.MaxAge)
+
+	input.Name = c.getQualifiedName(CONTAINER_VERSION, input.Name)
+	if err := c.updateResource(input.Name, headers); err != nil {
+		return nil, err
+	}
+
+	getInput := GetContainerInput{
+		Name: input.Name,
+	}
+	return c.GetContainer(&getInput)
+}
+
+func (c *StorageClient) success(rsp *http.Response, container *Container) (*Container, error) {
+	var err error
+	container.ReadACLs = strings.Split(rsp.Header.Get("X-Container-Read"), ",")
+	container.WriteACLs = strings.Split(rsp.Header.Get("X-Container-Write"), ",")
+	container.PrimaryKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key")
+	container.SecondaryKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key-2")
+	container.AllowedOrigins = strings.Split(rsp.Header.Get("X-Container-Meta-Access-Control-Expose-Headers"), " ")
+	container.MaxAge, err = strconv.Atoi(rsp.Header.Get("X-Container-Meta-Access-Control-Max-Age"))
+	if err != nil {
+		return nil, err
+	}
+
+	return container, nil
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_client.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -29,12 +28,6 @@ func NewStorageClient(c *opc.Config) (*StorageClient, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	endpoint, err := url.Parse(fmt.Sprintf("https://%s.storage.oraclecloud.com", *client.IdentityDomain))
-	if err != nil {
-		return nil, err
-	}
-	client.APIEndpoint = endpoint
 	storageClient.client = client
 
 	if err := storageClient.getAuthenticationToken(); err != nil {

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_client.go
@@ -1,0 +1,112 @@
+package storage
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-oracle-terraform/client"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const STR_ACCOUNT = "/Storage-%s"
+const STR_USERNAME = "/Storage-%s:%s"
+const AUTH_HEADER = "X-Auth-Token"
+const STR_QUALIFIED_NAME = "%s%s/%s"
+
+// Client represents an authenticated compute client, with compute credentials and an api client.
+type StorageClient struct {
+	client      *client.Client
+	authToken   *string
+	tokenIssued time.Time
+}
+
+func NewStorageClient(c *opc.Config) (*StorageClient, error) {
+	storageClient := &StorageClient{}
+	client, err := client.NewClient(c)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint, err := url.Parse(fmt.Sprintf("https://%s.storage.oraclecloud.com", *client.IdentityDomain))
+	if err != nil {
+		return nil, err
+	}
+	client.APIEndpoint = endpoint
+	storageClient.client = client
+
+	if err := storageClient.getAuthenticationToken(); err != nil {
+		return nil, err
+	}
+
+	return storageClient, nil
+}
+
+func (c *StorageClient) executeRequest(method, path string, headers interface{}) (*http.Response, error) {
+	req, err := c.client.BuildRequest(method, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if headers != nil {
+		for k, v := range headers.(map[string]string) {
+			req.Header.Add(k, v)
+		}
+	}
+
+	// If we have an authentication token, let's authenticate, refreshing cookie if need be
+	if c.authToken != nil {
+		if time.Since(c.tokenIssued).Minutes() > 25 {
+			if err := c.getAuthenticationToken(); err != nil {
+				return nil, err
+			}
+		}
+		req.Header.Add(AUTH_HEADER, *c.authToken)
+	}
+
+	resp, err := c.client.ExecuteRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *StorageClient) getUserName() string {
+	return fmt.Sprintf(STR_USERNAME, *c.client.IdentityDomain, *c.client.UserName)
+}
+
+func (c *StorageClient) getAccount() string {
+	return fmt.Sprintf(STR_ACCOUNT, *c.client.IdentityDomain)
+}
+
+// GetQualifiedName returns the fully-qualified name of a storage object, e.g. /v1/{account}/{name}
+func (c *StorageClient) getQualifiedName(version string, name string) string {
+	if name == "" {
+		return ""
+	}
+	if strings.HasPrefix(name, "/Storage-") || strings.HasPrefix(name, "v1/") {
+		return name
+	}
+	return fmt.Sprintf(STR_QUALIFIED_NAME, version, c.getAccount(), name)
+}
+
+// GetUnqualifiedName returns the unqualified name of a Storage object, e.g. the {name} part of /v1/{account}/{name}
+func (c *StorageClient) getUnqualifiedName(name string) string {
+	if name == "" {
+		return name
+	}
+	if !strings.Contains(name, "/") {
+		return name
+	}
+
+	nameParts := strings.Split(name, "/")
+	return strings.Join(nameParts[len(nameParts)-1:], "/")
+}
+
+func (c *StorageClient) unqualify(names ...*string) {
+	for _, name := range names {
+		*name = c.getUnqualifiedName(*name)
+	}
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_resource_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_resource_client.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"net/http"
+)
+
+func (c *StorageClient) createResource(name string, requestHeaders interface{}) error {
+	_, err := c.executeRequest("PUT", name, requestHeaders)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *StorageClient) updateResource(name string, requestHeaders interface{}) error {
+	_, err := c.executeRequest("PUT", name, requestHeaders)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *StorageClient) getResource(name string, responseBody interface{}) (*http.Response, error) {
+	rsp, err := c.executeRequest("GET", name, nil)
+	if err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
+func (c *StorageClient) deleteResource(name string) error {
+	_, err := c.executeRequest("DELETE", name, nil)
+	if err != nil {
+		return err
+	}
+
+	// No errors and no response body to write
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/test_utils.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/test_utils.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"time"
 
@@ -45,6 +46,14 @@ func getStorageTestClient(c *opc.Config) (*StorageClient, error) {
 	if c.Password == nil {
 		password := os.Getenv("OPC_PASSWORD")
 		c.Password = &password
+	}
+
+	if c.APIEndpoint == nil {
+		apiEndpoint, err := url.Parse(os.Getenv("OPC_STORAGE_ENDPOINT"))
+		if err != nil {
+			return nil, err
+		}
+		c.APIEndpoint = apiEndpoint
 	}
 
 	if c.HTTPClient == nil {

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/test_utils.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/test_utils.go
@@ -1,0 +1,59 @@
+package storage
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"time"
+
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const (
+	_ClientTestUser   = "test-user"
+	_ClientTestDomain = "test-domain"
+)
+
+func newAuthenticatingServer(handler func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if os.Getenv("ORACLE_LOG") != "" {
+			log.Printf("[DEBUG] Received request: %s, %s\n", r.Method, r.URL)
+		}
+
+		if r.URL.Path == "/authenticate/" {
+			http.SetCookie(w, &http.Cookie{Name: "testAuthCookie", Value: "cookie value"})
+		} else {
+			handler(w, r)
+		}
+	}))
+}
+
+func getStorageTestClient(c *opc.Config) (*StorageClient, error) {
+	// Build up config with default values if omitted
+
+	if c.IdentityDomain == nil {
+		domain := os.Getenv("OPC_IDENTITY_DOMAIN")
+		c.IdentityDomain = &domain
+	}
+
+	if c.Username == nil {
+		username := os.Getenv("OPC_USERNAME")
+		c.Username = &username
+	}
+
+	if c.Password == nil {
+		password := os.Getenv("OPC_PASSWORD")
+		c.Password = &password
+	}
+
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				Proxy:               http.ProxyFromEnvironment,
+				TLSHandshakeTimeout: 120 * time.Second},
+		}
+	}
+
+	return NewStorageClient(c)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,42 +250,42 @@
 		{
 			"checksumSHA1": "iG8sgf8Nq6SnoMY3wjK68eZ4f3g=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "f956284fe5df3df52e751daee8eac043127645f3",
-			"revisionTime": "2017-06-30T21:21:31Z",
-			"version": "=v0.1.4",
-			"versionExact": "v0.1.4"
+			"revision": "0d485077a4e239fbd4eb8ea6bd4ca8d4b41bdaec",
+			"revisionTime": "2017-07-05T17:51:25Z",
+			"version": "=v0.1.5",
+			"versionExact": "v0.1.5"
 		},
 		{
 			"checksumSHA1": "tzmsqBOStgusSQzWYOixWxhPm3I=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "f956284fe5df3df52e751daee8eac043127645f3",
-			"revisionTime": "2017-06-30T21:21:31Z",
-			"version": "=v0.1.4",
-			"versionExact": "v0.1.4"
+			"revision": "0d485077a4e239fbd4eb8ea6bd4ca8d4b41bdaec",
+			"revisionTime": "2017-07-05T17:51:25Z",
+			"version": "=v0.1.5",
+			"versionExact": "v0.1.5"
 		},
 		{
 			"checksumSHA1": "DzK7lYwHt5Isq5Zf73cnQqBO2LI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/helper",
-			"revision": "f956284fe5df3df52e751daee8eac043127645f3",
-			"revisionTime": "2017-06-30T21:21:31Z",
-			"version": "=v0.1.4",
-			"versionExact": "v0.1.4"
+			"revision": "0d485077a4e239fbd4eb8ea6bd4ca8d4b41bdaec",
+			"revisionTime": "2017-07-05T17:51:25Z",
+			"version": "=v0.1.5",
+			"versionExact": "v0.1.5"
 		},
 		{
 			"checksumSHA1": "JbuYtbJkx3r1BLuCMymkri0Q1BI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "f956284fe5df3df52e751daee8eac043127645f3",
-			"revisionTime": "2017-06-30T21:21:31Z",
-			"version": "=v0.1.4",
-			"versionExact": "v0.1.4"
+			"revision": "0d485077a4e239fbd4eb8ea6bd4ca8d4b41bdaec",
+			"revisionTime": "2017-07-05T17:51:25Z",
+			"version": "=v0.1.5",
+			"versionExact": "v0.1.5"
 		},
 		{
-			"checksumSHA1": "3Ptc/yHLX2MpV7AcU1F9EnRztjA=",
+			"checksumSHA1": "RZ0JXaeUyiGFdvoHV0jUgOSZjVY=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "f956284fe5df3df52e751daee8eac043127645f3",
-			"revisionTime": "2017-06-30T21:21:31Z",
-			"version": "=v0.1.4",
-			"versionExact": "v0.1.4"
+			"revision": "0d485077a4e239fbd4eb8ea6bd4ca8d4b41bdaec",
+			"revisionTime": "2017-07-05T17:51:25Z",
+			"version": "=v0.1.5",
+			"versionExact": "v0.1.5"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -280,6 +280,14 @@
 			"versionExact": "v0.1.4"
 		},
 		{
+			"checksumSHA1": "3Ptc/yHLX2MpV7AcU1F9EnRztjA=",
+			"path": "github.com/hashicorp/go-oracle-terraform/storage",
+			"revision": "f956284fe5df3df52e751daee8eac043127645f3",
+			"revisionTime": "2017-06-30T21:21:31Z",
+			"version": "=v0.1.4",
+			"versionExact": "v0.1.4"
+		},
+		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",
 			"path": "github.com/hashicorp/go-plugin",
 			"revision": "f72692aebca2008343a9deb06ddb4b17f7051c15",

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -45,8 +45,7 @@ The following arguments are supported:
 
 * `endpoint` - (Optional) The API endpoint to use, associated with your Oracle Public Cloud account. This is known as the `REST Endpoint` within the Oracle portal. It can also be sourced from the `OPC_ENDPOINT` environment variable.
 
-* `storage` - (Optional) Adds additional resources for Oracle IaaS Storage if the Oracle Account supports Storage
-Can also set via the `OPC_STORAGE` environment variable. Defaults to `false`.
+* `storage_endpoint` - (Optional) The API endpoint to use, associated with your Oracle Public Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_STORAGE_ENDPOINT` environment variable.
 
 * `max_retries` - (Optional) The maximum number of tries to make for a successful response when operating on resources within Oracle Public Cloud. It can also be sourced from the `OPC_MAX_RETRIES` environment variable. Defaults to 1.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -45,6 +45,9 @@ The following arguments are supported:
 
 * `endpoint` - (Optional) The API endpoint to use, associated with your Oracle Public Cloud account. This is known as the `REST Endpoint` within the Oracle portal. It can also be sourced from the `OPC_ENDPOINT` environment variable.
 
+* `storage` - (Optional) Adds additional resources for Oracle IaaS Storage if the Oracle Account supports Storage
+Can also set via the `OPC_STORAGE` environment variable. Defaults to `false`.
+
 * `max_retries` - (Optional) The maximum number of tries to make for a successful response when operating on resources within Oracle Public Cloud. It can also be sourced from the `OPC_MAX_RETRIES` environment variable. Defaults to 1.
 
 * `insecure` - (Optional) Skips TLS Verification for using self-signed certificates. Should only be used if absolutely needed. Can also via setting the `OPC_INSECURE` environment variable to `true`.

--- a/website/docs/r/opc_storage_container.html.markdown
+++ b/website/docs/r/opc_storage_container.html.markdown
@@ -3,14 +3,14 @@ layout: "opc"
 page_title: "Oracle: opc_storage_container"
 sidebar_current: "docs-opc-resource-storage-container"
 description: |-
-  Creates and manages a Container in the OPC Storage Domain. `storage` must be set to true in the
-  provider to manage these resources.
+  Creates and manages a Container in the OPC Storage Domain. `storage_endpoint` must be set in the
+  provider or environment to manage these resources.
 ---
 
 # opc\_storage\_container
 
-Creates and manages a Container in the OPC Storage Domain. `storage` must be set to true in the
-provider to manage these resources.
+Creates and manages a Container in the OPC Storage Domain. `storage_endpoint` must be set in the
+provider or environment to manage these resources.
 
 ## Example Usage
 

--- a/website/docs/r/opc_storage_container.html.markdown
+++ b/website/docs/r/opc_storage_container.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "opc"
+page_title: "Oracle: opc_storage_container"
+sidebar_current: "docs-opc-resource-storage-container"
+description: |-
+  Creates and manages a Container in the OPC Storage Domain. `storage` must be set to true in the
+  provider to manage these resources.
+---
+
+# opc\_storage\_container
+
+Creates and manages a Container in the OPC Storage Domain. `storage` must be set to true in the
+provider to manage these resources.
+
+## Example Usage
+
+```hcl
+resource "opc_storage_container" "default" {
+  name        = "storage-container-1"
+  read_acls   = ["read_acl_1", "read_acl_2"]
+  max_age = 60
+  primary_key = "primary-key-name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the ACL.
+
+* `read_acls` - (Optional) The list of ACLs that grant read access.
+
+* `write_acls` - (Optional) The list of ACLs that grant write access.
+
+* `primary_key` - (Optional) The primary secret key value for temporary URLs.
+
+* `secondary_key` - (Optional) The secondary secret key value for temporary URLs.
+
+* `allowed_origins` - (Optional) List of origins that are allowed to make cross-origin requests.
+
+* `max_age` - (Optional) Maximum age in seconds for the origin to hold the preflight results.
+
+## Import
+
+Container's can be imported using the `resource name`, e.g.
+
+```shell
+$ terraform import opc_storage_container.default example
+```

--- a/website/opc.erb
+++ b/website/opc.erb
@@ -94,6 +94,9 @@
                         <li<%= sidebar_current("docs-opc-resource-vnic-set") %>>
                             <a href="/docs/providers/opc/r/opc_compute_vnic_set.html">opc_compute_vnic_set</a>
                         </li>
+                        <li<%= sidebar_current("docs-opc-resource-storage-container") %>>
+                            <a href="/docs/providers/opc/r/opc_storage_container.html">opc_storage_container</a>
+                        </li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
This PR adds `storage_containers` to the Provider. It also has all resources use the `OPCClient` which holds a compute client and a storage client for their respective resources. Java and Database clients will also be added to `OPCClient` at a future date. To account for the `OPCClient` shift, all resources had to be refactored to use `OPCClient.computeClient`

```
TF_ACC=1 make test TEST=./opc TESTARGS="-v -run=TestAccOPCStorageContainer"
==> Checking that code complies with gofmt requirements...
go test -i ./opc || exit 1
echo ./opc | \
		xargs -t -n4 go test -v -run=TestAccOPCStorageContainer -timeout=300s -parallel=4
go test -v -run=TestAccOPCStorageContainer -timeout=300s -parallel=4 ./opc
=== RUN   TestAccOPCStorageContainer_importBasic
--- PASS: TestAccOPCStorageContainer_importBasic (14.48s)
=== RUN   TestAccOPCStorageContainer_Basic
--- PASS: TestAccOPCStorageContainer_Basic (13.18s)
=== RUN   TestAccOPCStorageContainer_Updated
--- PASS: TestAccOPCStorageContainer_Updated (25.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opc/opc	53.564s
```