### PR TITLE
r/security_list: Suppress case diffs for security_list

### DIFF
--- a/opc/import_security_list_test.go
+++ b/opc/import_security_list_test.go
@@ -1,7 +1,6 @@
 package opc
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -9,10 +8,8 @@ import (
 )
 
 func TestAccOPCSecurityList_importBasic(t *testing.T) {
-	resourceName := "opc_compute_security_list.test"
-
-	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOPCSecurityListBasic, ri)
+	rInt := acctest.RandInt()
+	rName := "opc_compute_security_list.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -22,10 +19,10 @@ func TestAccOPCSecurityList_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckSecurityListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccOPCSecurityListBasic(rInt),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -34,10 +31,8 @@ func TestAccOPCSecurityList_importBasic(t *testing.T) {
 }
 
 func TestAccOPCSecurityList_importComplete(t *testing.T) {
-	resourceName := "opc_compute_security_list.test"
-
-	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOPCSecurityListComplete, ri)
+	rInt := acctest.RandInt()
+	rName := "opc_compute_security_list.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -47,10 +42,10 @@ func TestAccOPCSecurityList_importComplete(t *testing.T) {
 		CheckDestroy: testAccCheckSecurityListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccOPCSecurityListComplete(rInt),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/opc/resource_security_list.go
+++ b/opc/resource_security_list.go
@@ -40,6 +40,7 @@ func resourceOPCSecurityList() *schema.Resource {
 					string(compute.SecurityListPolicyPermit),
 					string(compute.SecurityListPolicyReject),
 				}, true),
+				DiffSuppressFunc: suppressCaseDifferences,
 			},
 
 			"outbound_cidr_policy": {
@@ -51,6 +52,7 @@ func resourceOPCSecurityList() *schema.Resource {
 					string(compute.SecurityListPolicyPermit),
 					string(compute.SecurityListPolicyReject),
 				}, true),
+				DiffSuppressFunc: suppressCaseDifferences,
 			},
 		},
 	}

--- a/opc/resource_security_list_test.go
+++ b/opc/resource_security_list_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestAccOPCSecurityList_basic(t *testing.T) {
-	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOPCSecurityListBasic, ri)
+	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("acc-test-sec-list-%d.test", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,16 +20,20 @@ func TestAccOPCSecurityList_basic(t *testing.T) {
 		CheckDestroy: testAccCheckSecurityListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
-				Check:  testAccCheckSecurityListExists,
+				Config: testAccOPCSecurityListBasic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityListExists,
+					resource.TestCheckResourceAttr(rName, "policy", "PERMIT"),
+					resource.TestCheckResourceAttr(rName, "outbound_cidr_policy", "DENY"),
+				),
 			},
 		},
 	})
 }
 
 func TestAccOPCSecurityList_complete(t *testing.T) {
-	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOPCSecurityListComplete, ri)
+	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("acc-test-sec-list-%d.test", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,7 +41,28 @@ func TestAccOPCSecurityList_complete(t *testing.T) {
 		CheckDestroy: testAccCheckSecurityListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccOPCSecurityListComplete(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityListExists,
+					resource.TestCheckResourceAttr(rName, "policy", "PERMIT"),
+					resource.TestCheckResourceAttr(rName, "outbound_cidr_policy", "DENY"),
+					resource.TestCheckResourceAttr(rName, "description", "Acceptance Test Security List Complete"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOPCSecurityList_lowercasePolicies(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSecurityListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOPCSecurityListLowercasePolicies(rInt),
 				Check:  testAccCheckSecurityListExists,
 			},
 		},
@@ -82,19 +107,31 @@ func testAccCheckSecurityListDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccOPCSecurityListBasic = `
+func testAccOPCSecurityListBasic(rInt int) string {
+	return fmt.Sprintf(`
 resource "opc_compute_security_list" "test" {
-  name                 = "acc-test-sec-list-%d"
-  policy               = "PERMIT"
-  outbound_cidr_policy = "DENY"
+	name                 = "acc-test-sec-list-%d"
+	policy               = "PERMIT"
+	outbound_cidr_policy = "DENY"
+}`, rInt)
 }
-`
 
-const testAccOPCSecurityListComplete = `
+func testAccOPCSecurityListComplete(rInt int) string {
+	return fmt.Sprintf(`
 resource "opc_compute_security_list" "test" {
-  name                 = "acc-test-sec-list-%d"
-  description          = "Acceptance Test Security List Complete"
-  policy               = "PERMIT"
-  outbound_cidr_policy = "DENY"
+ name                 = "acc-test-sec-list-%d"
+ description          = "Acceptance Test Security List Complete"
+ policy               = "PERMIT"
+ outbound_cidr_policy = "DENY"
+}`, rInt)
 }
-`
+
+func testAccOPCSecurityListLowercasePolicies(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_security_list" "test" {
+ name                 = "acc-test-sec-list-%d"
+ description          = "Acceptance Test Security List Complete"
+ policy               = "permit"
+ outbound_cidr_policy = "deny"
+}`, rInt)
+}

--- a/opc/resource_security_list_test.go
+++ b/opc/resource_security_list_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccOPCSecurityList_basic(t *testing.T) {
 	rInt := acctest.RandInt()
-	rName := fmt.Sprintf("acc-test-sec-list-%d.test", rInt)
+	rName := "opc_compute_security_list.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -33,7 +33,7 @@ func TestAccOPCSecurityList_basic(t *testing.T) {
 
 func TestAccOPCSecurityList_complete(t *testing.T) {
 	rInt := acctest.RandInt()
-	rName := fmt.Sprintf("acc-test-sec-list-%d.test", rInt)
+	rName := "opc_compute_security_list.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -55,6 +55,7 @@ func TestAccOPCSecurityList_complete(t *testing.T) {
 
 func TestAccOPCSecurityList_lowercasePolicies(t *testing.T) {
 	rInt := acctest.RandInt()
+	rName := "opc_compute_security_list.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,7 +64,12 @@ func TestAccOPCSecurityList_lowercasePolicies(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOPCSecurityListLowercasePolicies(rInt),
-				Check:  testAccCheckSecurityListExists,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityListExists,
+					resource.TestCheckResourceAttr(rName, "policy", "PERMIT"),
+					resource.TestCheckResourceAttr(rName, "outbound_cidr_policy", "DENY"),
+					resource.TestCheckResourceAttr(rName, "description", "Acceptance Test Security List Lowercase"),
+				),
 			},
 		},
 	})
@@ -130,7 +136,7 @@ func testAccOPCSecurityListLowercasePolicies(rInt int) string {
 	return fmt.Sprintf(`
 resource "opc_compute_security_list" "test" {
  name                 = "acc-test-sec-list-%d"
- description          = "Acceptance Test Security List Complete"
+ description          = "Acceptance Test Security List Lowercase"
  policy               = "permit"
  outbound_cidr_policy = "deny"
 }`, rInt)

--- a/opc/suppressors.go
+++ b/opc/suppressors.go
@@ -1,0 +1,15 @@
+package opc
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// Suppress Diff on mismatched case
+func suppressCaseDifferences(k, old, new string, d *schema.ResourceData) bool {
+	if strings.ToLower(old) == strings.ToLower(new) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
With `outbound_cidr_policy` and `policy` attributes, the API returns a fully upper-case value regardless of a lower-case value being supplied. Needed to suppress the diff with the updated value to ignore case.

Fixes: #17 