### PR TITLE
Add timeout configuration:

### DIFF
--- a/opc/resource_instance.go
+++ b/opc/resource_instance.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-oracle-terraform/client"
 	"github.com/hashicorp/go-oracle-terraform/compute"
@@ -31,6 +32,12 @@ func resourceInstance() *schema.Resource {
 				d.SetId(combined[1])
 				return []*schema.ResourceData{d}, nil
 			},
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -367,8 +374,9 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Get Required Attributes
 	input := &compute.CreateInstanceInput{
-		Name:  d.Get("name").(string),
-		Shape: d.Get("shape").(string),
+		Name:    d.Get("name").(string),
+		Shape:   d.Get("shape").(string),
+		Timeout: d.Timeout(schema.TimeoutCreate),
 	}
 
 	// Get optional instance attributes
@@ -554,8 +562,9 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 
 	input := &compute.UpdateInstanceInput{
-		Name: name,
-		ID:   d.Id(),
+		Name:    name,
+		ID:      d.Id(),
+		Timeout: d.Timeout(schema.TimeoutUpdate),
 	}
 
 	if d.HasChange("desired_state") {
@@ -584,8 +593,9 @@ func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 
 	input := &compute.DeleteInstanceInput{
-		ID:   d.Id(),
-		Name: name,
+		ID:      d.Id(),
+		Name:    name,
+		Timeout: d.Timeout(schema.TimeoutDelete),
 	}
 	log.Printf("[DEBUG] Deleting instance %s", name)
 

--- a/opc/resource_storage_volume.go
+++ b/opc/resource_storage_volume.go
@@ -3,6 +3,7 @@ package opc
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/go-oracle-terraform/client"
 	"github.com/hashicorp/go-oracle-terraform/compute"
@@ -18,6 +19,12 @@ func resourceOPCStorageVolume() *schema.Resource {
 		Delete: resourceOPCStorageVolumeDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -153,6 +160,7 @@ func resourceOPCStorageVolumeCreate(d *schema.ResourceData, meta interface{}) er
 		ImageList:      imageList,
 		ImageListEntry: imageListEntry,
 		Tags:           getStringList(d, "tags"),
+		Timeout:        d.Timeout(schema.TimeoutCreate),
 	}
 
 	if v, ok := d.GetOk("snapshot"); ok {
@@ -192,6 +200,7 @@ func resourceOPCStorageVolumeUpdate(d *schema.ResourceData, meta interface{}) er
 		ImageList:      imageList,
 		ImageListEntry: imageListEntry,
 		Tags:           getStringList(d, "tags"),
+		Timeout:        d.Timeout(schema.TimeoutUpdate),
 	}
 	_, err := client.UpdateStorageVolume(&input)
 	if err != nil {
@@ -255,7 +264,8 @@ func resourceOPCStorageVolumeDelete(d *schema.ResourceData, meta interface{}) er
 	name := d.Id()
 
 	input := compute.DeleteStorageVolumeInput{
-		Name: name,
+		Name:    name,
+		Timeout: d.Timeout(schema.TimeoutDelete),
 	}
 	err := client.DeleteStorageVolume(&input)
 	if err != nil {

--- a/opc/resource_storage_volume_snapshot.go
+++ b/opc/resource_storage_volume_snapshot.go
@@ -3,6 +3,7 @@ package opc
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/go-oracle-terraform/client"
 	"github.com/hashicorp/go-oracle-terraform/compute"
@@ -16,6 +17,11 @@ func resourceOPCStorageVolumeSnapshot() *schema.Resource {
 		Delete: resourceOPCStorageVolumeSnapshotDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -126,7 +132,8 @@ func resourceOPCStorageVolumeSnapshotCreate(d *schema.ResourceData, meta interfa
 
 	// Get required attribute
 	input := &compute.CreateStorageVolumeSnapshotInput{
-		Volume: d.Get("volume_name").(string),
+		Volume:  d.Get("volume_name").(string),
+		Timeout: d.Timeout(schema.TimeoutCreate),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -226,7 +233,8 @@ func resourceOPCStorageVolumeSnapshotDelete(d *schema.ResourceData, meta interfa
 	name := d.Id()
 
 	input := &compute.DeleteStorageVolumeSnapshotInput{
-		Name: name,
+		Name:    name,
+		Timeout: d.Timeout(schema.TimeoutDelete),
 	}
 
 	if err := client.DeleteStorageVolumeSnapshot(input); err != nil {

--- a/vendor/github.com/hashicorp/go-oracle-terraform/client/client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/client/client.go
@@ -171,8 +171,10 @@ func (c *Client) formatURL(path *url.URL) string {
 }
 
 // Retry function
-func (c *Client) WaitFor(description string, timeoutSeconds int, test func() (bool, error)) error {
+func (c *Client) WaitFor(description string, timeout time.Duration, test func() (bool, error)) error {
 	tick := time.Tick(1 * time.Second)
+
+	timeoutSeconds := int(timeout.Seconds())
 
 	for i := 0; i < timeoutSeconds; i++ {
 		select {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -248,36 +248,36 @@
 			"revision": "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
 		},
 		{
-			"checksumSHA1": "iG8sgf8Nq6SnoMY3wjK68eZ4f3g=",
+			"checksumSHA1": "zna4OotvTDjb26NKZ1Y4kwDPZGM=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "0d485077a4e239fbd4eb8ea6bd4ca8d4b41bdaec",
-			"revisionTime": "2017-07-05T17:51:25Z",
-			"version": "=v0.1.5",
-			"versionExact": "v0.1.5"
+			"revision": "179f35b8fe403a090168d1d8f67b1c1f192914dc",
+			"revisionTime": "2017-07-19T14:17:38Z",
+			"version": "v0.1.7",
+			"versionExact": "v0.1.7"
 		},
 		{
-			"checksumSHA1": "tzmsqBOStgusSQzWYOixWxhPm3I=",
+			"checksumSHA1": "N7ghAYSHczBQIG/J8XIDd7uWHEk=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "0d485077a4e239fbd4eb8ea6bd4ca8d4b41bdaec",
-			"revisionTime": "2017-07-05T17:51:25Z",
-			"version": "=v0.1.5",
-			"versionExact": "v0.1.5"
+			"revision": "179f35b8fe403a090168d1d8f67b1c1f192914dc",
+			"revisionTime": "2017-07-19T14:17:38Z",
+			"version": "v0.1.7",
+			"versionExact": "v0.1.7"
 		},
 		{
 			"checksumSHA1": "JbuYtbJkx3r1BLuCMymkri0Q1BI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "0d485077a4e239fbd4eb8ea6bd4ca8d4b41bdaec",
-			"revisionTime": "2017-07-05T17:51:25Z",
-			"version": "=v0.1.5",
-			"versionExact": "v0.1.5"
+			"revision": "179f35b8fe403a090168d1d8f67b1c1f192914dc",
+			"revisionTime": "2017-07-19T14:17:38Z",
+			"version": "v0.1.7",
+			"versionExact": "v0.1.7"
 		},
 		{
 			"checksumSHA1": "RZ0JXaeUyiGFdvoHV0jUgOSZjVY=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "0d485077a4e239fbd4eb8ea6bd4ca8d4b41bdaec",
-			"revisionTime": "2017-07-05T17:51:25Z",
-			"version": "=v0.1.5",
-			"versionExact": "v0.1.5"
+			"revision": "179f35b8fe403a090168d1d8f67b1c1f192914dc",
+			"revisionTime": "2017-07-19T14:17:38Z",
+			"version": "v0.1.7",
+			"versionExact": "v0.1.7"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/website/docs/r/opc_compute_instance.html.markdown
+++ b/website/docs/r/opc_compute_instance.html.markdown
@@ -197,3 +197,13 @@ The instance can be imported as such:
 ```shell
 $ terraform import opc_compute_instance.instance1 instance_name/instance_id
 ```
+
+<a id="timeouts"></a>
+## Timeouts
+
+`opc_compute_instance` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `20 minutes`) Used for Creating Instances.
+- `update` - (Default `20 minutes`) Used for updating Instances.
+- `delete` - (Default `20 minutes`) Used for Deleting Instances.

--- a/website/docs/r/opc_compute_storage_volume.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume.html.markdown
@@ -83,3 +83,14 @@ Storage Volume's can be imported using the `resource name`, e.g.
 ```shell
 $ terraform import opc_compute_storage_volume.volume1 example
 ```
+
+<a id="timeouts"></a>
+## Timeouts
+
+`opc_compute_storage_volume` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `30 minutes`) Used for Creating Storage Volumes.
+- `update` - (Default `30 minutes`) Used for Modifying Storage Volumes.
+- `delete` - (Default `30 minutes`) Used for Deleting Storage Volumes.
+

--- a/website/docs/r/opc_compute_storage_volume_snapshot.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume_snapshot.html.markdown
@@ -57,3 +57,12 @@ Storage Volume Snapshot's can be imported using the `resource name`, e.g.
 ```shell
 $ terraform import opc_compute_storage_volume_snapshot.volume1 example
 ```
+
+<a id="timeouts"></a>
+## Timeouts
+
+`opc_compute_storage_volume_snapshot` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `30 minutes`) Used for Creating Storage Volume Snapshots.
+- `delete` - (Default `30 minutes`) Used for Deleting Storage Volume Snapshots.


### PR DESCRIPTION
Adds timeout configuration for the following:

- `opc_compute_storage_volume`:
  - Create
  - Update
  - Delete

- `opc_compute_storage_volume_snapshot`:
  - Create
  - Delete

- `opc_compute_instance`:
  - Create
  - Update
  - Delete

Fixes: #35, #34 