### PR TITLE
Add service instance

### DIFF
--- a/opc/config.go
+++ b/opc/config.go
@@ -9,24 +9,27 @@ import (
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-oracle-terraform/compute"
+	"github.com/hashicorp/go-oracle-terraform/database"
 	"github.com/hashicorp/go-oracle-terraform/opc"
 	"github.com/hashicorp/go-oracle-terraform/storage"
 	"github.com/hashicorp/terraform/helper/logging"
 )
 
 type Config struct {
-	User            string
-	Password        string
-	IdentityDomain  string
-	Endpoint        string
-	MaxRetries      int
-	Insecure        bool
-	StorageEndpoint string
+	User             string
+	Password         string
+	IdentityDomain   string
+	Endpoint         string
+	MaxRetries       int
+	Insecure         bool
+	StorageEndpoint  string
+	DatabaseEndpoint string
 }
 
 type OPCClient struct {
-	computeClient *compute.ComputeClient
-	storageClient *storage.StorageClient
+	computeClient  *compute.ComputeClient
+	storageClient  *storage.StorageClient
+	databaseClient *database.DatabaseClient
 }
 
 func (c *Config) Client() (*OPCClient, error) {
@@ -80,6 +83,19 @@ func (c *Config) Client() (*OPCClient, error) {
 			return nil, err
 		}
 		opcClient.storageClient = storageClient
+	}
+
+	if c.DatabaseEndpoint != "" {
+		databaseEndpoint, err := url.ParseRequestURI(c.DatabaseEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid database endpoint URI: %s", err)
+		}
+		config.APIEndpoint = databaseEndpoint
+		databaseClient, err := database.NewDatabaseClient(&config)
+		if err != nil {
+			return nil, err
+		}
+		opcClient.databaseClient = databaseClient
 	}
 
 	return opcClient, nil

--- a/opc/config.go
+++ b/opc/config.go
@@ -75,7 +75,7 @@ func (c *Config) Client() (*OPCClient, error) {
 	if c.StorageEndpoint != "" {
 		storageEndpoint, err := url.ParseRequestURI(c.StorageEndpoint)
 		if err != nil {
-			return nil, fmt.Errorf("Invalid storage endpoint URI: %s", err)
+			return nil, fmt.Errorf("Invalid storage endpoint URI: %+v", err)
 		}
 		config.APIEndpoint = storageEndpoint
 		storageClient, err := storage.NewStorageClient(&config)
@@ -88,7 +88,7 @@ func (c *Config) Client() (*OPCClient, error) {
 	if c.DatabaseEndpoint != "" {
 		databaseEndpoint, err := url.ParseRequestURI(c.DatabaseEndpoint)
 		if err != nil {
-			return nil, fmt.Errorf("Invalid database endpoint URI: %s", err)
+			return nil, fmt.Errorf("Invalid database endpoint URI: %+v", err)
 		}
 		config.APIEndpoint = databaseEndpoint
 		databaseClient, err := database.NewDatabaseClient(&config)

--- a/opc/import_database_service_instance_test.go
+++ b/opc/import_database_service_instance_test.go
@@ -1,0 +1,1 @@
+package opc

--- a/opc/import_database_service_instance_test.go
+++ b/opc/import_database_service_instance_test.go
@@ -24,9 +24,10 @@ func TestAccOPCDatabaseServiceInstance_importBasic(t *testing.T) {
 				Config: config,
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameter", "vm_public_key"},
 			},
 		},
 	})

--- a/opc/import_database_service_instance_test.go
+++ b/opc/import_database_service_instance_test.go
@@ -1,1 +1,33 @@
 package opc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOPCDatabaseServiceInstance_importBasic(t *testing.T) {
+	resourceName := "opc_database_service_instance.test"
+
+	ri := acctest.RandInt()
+	config := testAccDatabaseServiceInstanceBasic(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabaseServiceInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -56,7 +56,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("OPC_STORAGE_ENDPOINT", nil),
 				Description: "The HTTP endpoint for Oracle Storage operations.",
 			},
-			"database_endpont": {
+			"database_endpoint": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OPC_DATABASE_ENDPOINT", nil),
@@ -111,7 +111,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		MaxRetries:       d.Get("max_retries").(int),
 		Insecure:         d.Get("insecure").(bool),
 		StorageEndpoint:  d.Get("storage_endpoint").(string),
-		DatabaseEndpoint: d.Get("database_endpont").(string),
+		DatabaseEndpoint: d.Get("database_endpoint").(string),
 	}
 
 	return config.Client()

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -56,6 +56,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("OPC_STORAGE_ENDPOINT", nil),
 				Description: "The HTTP endpoint for Oracle Storage operations.",
 			},
+			"database_endpont": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OPC_DATABASE_ENDPOINT", nil),
+				Description: "The HTTP endpoint for Oracle Database operations.",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -89,6 +95,7 @@ func Provider() terraform.ResourceProvider {
 			"opc_compute_ip_address_association":  resourceOPCIPAddressAssociation(),
 			"opc_compute_snapshot":                resourceOPCSnapshot(),
 			"opc_storage_container":               resourceOPCStorageContainer(),
+			"opc_database_service_instance":       resourceOPCDatabaseServiceInstance(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -97,13 +104,14 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		User:            d.Get("user").(string),
-		Password:        d.Get("password").(string),
-		IdentityDomain:  d.Get("identity_domain").(string),
-		Endpoint:        d.Get("endpoint").(string),
-		MaxRetries:      d.Get("max_retries").(int),
-		Insecure:        d.Get("insecure").(bool),
-		StorageEndpoint: d.Get("storage_endpoint").(string),
+		User:             d.Get("user").(string),
+		Password:         d.Get("password").(string),
+		IdentityDomain:   d.Get("identity_domain").(string),
+		Endpoint:         d.Get("endpoint").(string),
+		MaxRetries:       d.Get("max_retries").(int),
+		Insecure:         d.Get("insecure").(bool),
+		StorageEndpoint:  d.Get("storage_endpoint").(string),
+		DatabaseEndpoint: d.Get("database_endpont").(string),
 	}
 
 	return config.Client()

--- a/opc/provider_test.go
+++ b/opc/provider_test.go
@@ -50,7 +50,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 	client, err := config.Client()
 	if err != nil {
-		t.Fatal(fmt.Sprintf("%s", err))
+		t.Fatal(fmt.Sprintf("%+v", err))
 	}
 	if client.storageClient == nil {
 		t.Fatalf("Storage Client is nil. Make sure your Oracle Cloud Account has access to the Storage Cloud")

--- a/opc/provider_test.go
+++ b/opc/provider_test.go
@@ -38,6 +38,26 @@ func testAccPreCheck(t *testing.T) {
 			t.Fatalf("%s must be set for acceptance test", prop)
 		}
 	}
+	config := Config{
+		User:             os.Getenv("OPC_USERNAME"),
+		Password:         os.Getenv("OPC_PASSWORD"),
+		IdentityDomain:   os.Getenv("OPC_IDENTITY_DOMAIN"),
+		Endpoint:         os.Getenv("OPC_ENDPOINT"),
+		MaxRetries:       1,
+		Insecure:         false,
+		StorageEndpoint:  os.Getenv("OPC_STORAGE_ENDPOINT"),
+		DatabaseEndpoint: os.Getenv("OPC_DATABASE_ENDPOINT"),
+	}
+	client, err := config.Client()
+	if err != nil {
+		t.Fatal(fmt.Sprintf("%s", err))
+	}
+	if client.storageClient == nil {
+		t.Fatalf("Storage Client is nil. Make sure your Oracle Cloud Account has access to the Storage Cloud")
+	}
+	if client.databaseClient == nil {
+		t.Fatalf("Database Client is nil. Make sure your Oracle Cloud Account has access to the Database Cloud")
+	}
 }
 
 type OPCResourceState struct {

--- a/opc/provider_test.go
+++ b/opc/provider_test.go
@@ -32,7 +32,7 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	required := []string{"OPC_USERNAME", "OPC_PASSWORD", "OPC_IDENTITY_DOMAIN", "OPC_ENDPOINT", "OPC_STORAGE_ENDPOINT"}
+	required := []string{"OPC_USERNAME", "OPC_PASSWORD", "OPC_IDENTITY_DOMAIN", "OPC_ENDPOINT", "OPC_STORAGE_ENDPOINT", "OPC_DATABASE_ENDPOINT"}
 	for _, prop := range required {
 		if os.Getenv(prop) == "" {
 			t.Fatalf("%s must be set for acceptance test", prop)

--- a/opc/resource_database_service_instance.go
+++ b/opc/resource_database_service_instance.go
@@ -410,6 +410,9 @@ func resourceOPCDatabaseServiceInstanceCreate(d *schema.ResourceData, meta inter
 	log.Print("[DEBUG] Creating database service instance")
 
 	client := meta.(*OPCClient).databaseClient.ServiceInstanceClient()
+	if client == nil {
+		return fmt.Errorf("Database Client is not initialized. Make sure to use `database_endpoint` variable or `OPC_DATABASE_ENDPOINT` env variable")
+	}
 	input := database.CreateServiceInstanceInput{
 		Name:             d.Get("name").(string),
 		Edition:          database.ServiceInstanceEdition(d.Get("edition").(string)),
@@ -440,6 +443,9 @@ func resourceOPCDatabaseServiceInstanceCreate(d *schema.ResourceData, meta inter
 func resourceOPCDatabaseServiceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
 	databaseClient := meta.(*OPCClient).databaseClient.ServiceInstanceClient()
+	if databaseClient == nil {
+		return fmt.Errorf("Database Client is not initialized. Make sure to use `database_endpoint` variable or `OPC_DATABASE_ENDPOINT` env variable")
+	}
 
 	log.Printf("[DEBUG] Reading state of ip reservation %s", d.Id())
 	getInput := database.GetServiceInstanceInput{
@@ -508,6 +514,9 @@ func resourceOPCDatabaseServiceInstanceRead(d *schema.ResourceData, meta interfa
 func resourceOPCDatabaseServiceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
 	client := meta.(*OPCClient).databaseClient.ServiceInstanceClient()
+	if client == nil {
+		return fmt.Errorf("Database Client is not initialized. Make sure to use `database_endpoint` variable or `OPC_DATABASE_ENDPOINT` env variable")
+	}
 	name := d.Id()
 
 	log.Printf("[DEBUG] Deleting DatabaseServiceInstance: %v", name)

--- a/opc/resource_database_service_instance.go
+++ b/opc/resource_database_service_instance.go
@@ -202,14 +202,17 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cloud_storage_password": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							DefaultFunc: schema.EnvDefaultFunc("OPC_PASSWORD", nil),
+							Sensitive:   true,
 						},
 						"cloud_storage_username": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							DefaultFunc: schema.EnvDefaultFunc("OPC_USERNAME", nil),
 						},
 						"database_id": {
 							Type:     schema.TypeString,
@@ -242,14 +245,17 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 							ForceNew: true,
 						},
 						"username": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							DefaultFunc: schema.EnvDefaultFunc("OPC_USERNAME", nil),
+							ForceNew:    true,
 						},
 						"password": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							DefaultFunc: schema.EnvDefaultFunc("OPC_PASSWORD", nil),
+							Sensitive:   true,
 						},
 						"create_if_missing": {
 							Type:     schema.TypeBool,
@@ -266,6 +272,11 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 				Computed: true,
 			},
 			"backup_supported_version": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Computed: true,
+			},
+			"cloud_storage_container": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Computed: true,
@@ -302,6 +313,11 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 			},
 			"em_url": {
 				Type:     schema.TypeString,
+				ForceNew: true,
+				Computed: true,
+			},
+			"failover_database": {
+				Type:     schema.TypeBool,
 				ForceNew: true,
 				Computed: true,
 			},

--- a/opc/resource_database_service_instance.go
+++ b/opc/resource_database_service_instance.go
@@ -320,7 +320,7 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
-			"dbaasmonitor_url": {
+			"dbaas_monitor_url": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Computed: true,
@@ -428,12 +428,12 @@ func resourceOPCDatabaseServiceInstanceCreate(d *schema.ResourceData, meta inter
 
 	// Only the PaaS level can have a parameter.
 	if input.Level == database.ServiceInstanceLevelPAAS {
-		input.Parameters = getParameter(d)
+		input.Parameters = expandParameter(d)
 	}
 
 	info, err := client.CreateServiceInstance(&input)
 	if err != nil {
-		return fmt.Errorf("Error creating DatabaseServiceInstance: %s", err)
+		return fmt.Errorf("Error creating DatabaseServiceInstance: %+v", err)
 	}
 
 	d.SetId(info.Name)
@@ -459,7 +459,7 @@ func resourceOPCDatabaseServiceInstanceRead(d *schema.ResourceData, meta interfa
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading database service instance %s: %s", d.Id(), err)
+		return fmt.Errorf("Error reading database service instance %s: %+v", d.Id(), err)
 	}
 
 	if result == nil {
@@ -481,7 +481,7 @@ func resourceOPCDatabaseServiceInstanceRead(d *schema.ResourceData, meta interfa
 	d.Set("created_by", result.CreatedBy)
 	d.Set("creation_time", result.CreationTime)
 	d.Set("current_version", result.CurrentVersion)
-	d.Set("dbaasmonitor_url", result.DBAASMonitorURL)
+	d.Set("dbaas_monitor_url", result.DBAASMonitorURL)
 	d.Set("edition", result.Edition)
 	d.Set("em_url", result.EMURL)
 	d.Set("failover_database", result.FailoverDatabase)
@@ -525,12 +525,12 @@ func resourceOPCDatabaseServiceInstanceDelete(d *schema.ResourceData, meta inter
 		Name: name,
 	}
 	if err := client.DeleteServiceInstance(&input); err != nil {
-		return fmt.Errorf("Error deleting DatabaseServiceInstance")
+		return fmt.Errorf("Error deleting DatabaseServiceInstance: %+v", err)
 	}
 	return nil
 }
 
-func getParameter(d *schema.ResourceData) []database.Parameter {
+func expandParameter(d *schema.ResourceData) []database.Parameter {
 	info := d.Get("parameter").(*schema.Set)
 	var parameter database.Parameter
 	for _, i := range info.List() {

--- a/opc/resource_database_service_instance.go
+++ b/opc/resource_database_service_instance.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/go-oracle-terraform/client"
+	opcClient "github.com/hashicorp/go-oracle-terraform/client"
 	"github.com/hashicorp/go-oracle-terraform/database"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -442,8 +442,8 @@ func resourceOPCDatabaseServiceInstanceCreate(d *schema.ResourceData, meta inter
 
 func resourceOPCDatabaseServiceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	databaseClient := meta.(*OPCClient).databaseClient.ServiceInstanceClient()
-	if databaseClient == nil {
+	client := meta.(*OPCClient).databaseClient.ServiceInstanceClient()
+	if client == nil {
 		return fmt.Errorf("Database Client is not initialized. Make sure to use `database_endpoint` variable or `OPC_DATABASE_ENDPOINT` env variable")
 	}
 
@@ -452,10 +452,10 @@ func resourceOPCDatabaseServiceInstanceRead(d *schema.ResourceData, meta interfa
 		Name: d.Id(),
 	}
 
-	result, err := databaseClient.GetServiceInstance(&getInput)
+	result, err := client.GetServiceInstance(&getInput)
 	if err != nil {
 		// DatabaseServiceInstance does not exist
-		if client.WasNotFoundError(err) {
+		if opcClient.WasNotFoundError(err) {
 			d.SetId("")
 			return nil
 		}

--- a/opc/resource_database_service_instance.go
+++ b/opc/resource_database_service_instance.go
@@ -61,16 +61,6 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(database.ServiceInstanceShapeOC3),
-					string(database.ServiceInstanceShapeOC4),
-					string(database.ServiceInstanceShapeOC5),
-					string(database.ServiceInstanceShapeOC6),
-					string(database.ServiceInstanceShapeOC1M),
-					string(database.ServiceInstanceShapeOC2M),
-					string(database.ServiceInstanceShapeOC3M),
-					string(database.ServiceInstanceShapeOC4M),
-				}, true),
 			},
 			"subscription_type": {
 				Type:     schema.TypeString,
@@ -85,11 +75,6 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(database.ServiceInstanceVersion12201),
-					string(database.ServiceInstanceVersion12102),
-					string(database.ServiceInstanceVersion11204),
-				}, true),
 			},
 			"vm_public_key": {
 				Type:     schema.TypeString,
@@ -104,13 +89,9 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"db_demo": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(database.ServiceInstanceYes),
-								string(database.ServiceInstanceNo),
-							}, true),
 						},
 						"admin_password": {
 							Type:     schema.TypeString,
@@ -133,101 +114,29 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 							ForceNew: true,
 							Default:  "AL32UTF8",
 						},
-						"cloud_storage_container": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"cloud_storage_username": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"cloud_storage_password": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"create_storage_container_if_missing": {
+						"disaster_recovery": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 							Default:  false,
-							ForceNew: true,
-						},
-						"disaster_recovery": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-							Default:  database.ServiceInstanceNo,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(database.ServiceInstanceYes),
-								string(database.ServiceInstanceNo),
-							}, true),
 						},
 						"failover_database": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
-							Default:  database.ServiceInstanceNo,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(database.ServiceInstanceYes),
-								string(database.ServiceInstanceNo),
-							}, true),
+							Default:  false,
 						},
 						"golden_gate": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
-							Default:  database.ServiceInstanceNo,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(database.ServiceInstanceYes),
-								string(database.ServiceInstanceNo),
-							}, true),
-						},
-						"ibkup": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-							Default:  database.ServiceInstanceNo,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(database.ServiceInstanceYes),
-								string(database.ServiceInstanceNo),
-							}, true),
-						},
-						"ibkup_cloud_storage_password": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"ibkup_cloud_storage_username": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"ibkup_database_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"ibkup_decryption_key": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"ibkup_wallet_file_content": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Default:  false,
 						},
 						"is_rac": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
-							Default:  database.ServiceInstanceNo,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(database.ServiceInstanceYes),
-								string(database.ServiceInstanceNo),
-							}, true),
+							Default:  false,
 						},
 						"n_char_set": {
 							Type:     schema.TypeString,
@@ -281,6 +190,72 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 							Required:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(15, 2048),
+						},
+					},
+				},
+			},
+			"ibkup": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cloud_storage_password": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"cloud_storage_username": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"database_id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"decryption_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"ibkup_wallet_file_content": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"cloud_storage": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"container": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"username": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"password": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"create_if_missing": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+							ForceNew: true,
 						},
 					},
 				},
@@ -428,7 +403,7 @@ func resourceOPCDatabaseServiceInstanceCreate(d *schema.ResourceData, meta inter
 
 	// Only the PaaS level can have a parameter.
 	if input.Level == database.ServiceInstanceLevelPAAS {
-		input.Parameters = expandParameter(d)
+		input.Parameters = expandParameter(client, d)
 	}
 
 	info, err := client.CreateServiceInstance(&input)
@@ -508,6 +483,7 @@ func resourceOPCDatabaseServiceInstanceRead(d *schema.ResourceData, meta interfa
 	d.Set("timezone", result.Timezone)
 	d.Set("total_shared_storage", result.TotalSharedStorage)
 	d.Set("version", result.Version)
+	// TODO Add parameter and vm_public_key to read when they get added to api.
 	return nil
 }
 
@@ -530,65 +506,69 @@ func resourceOPCDatabaseServiceInstanceDelete(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func expandParameter(d *schema.ResourceData) []database.Parameter {
-	info := d.Get("parameter").(*schema.Set)
+func expandParameter(client *database.ServiceInstanceClient, d *schema.ResourceData) []database.Parameter {
+	parameterInfo := d.Get("parameter").(*schema.Set)
 	var parameter database.Parameter
-	for _, i := range info.List() {
+	for _, i := range parameterInfo.List() {
 		attrs := i.(map[string]interface{})
 		parameter = database.Parameter{
 			AdminPassword:     attrs["admin_password"].(string),
 			BackupDestination: database.ServiceInstanceBackupDestination(attrs["backup_destination"].(string)),
 			CharSet:           attrs["char_set"].(string),
-			CreateStorageContainerIfMissing: attrs["create_storage_container_if_missing"].(bool),
-			DisasterRecovery:                database.ServiceInstanceBool(attrs["disaster_recovery"].(string)),
-			FailoverDatabase:                database.ServiceInstanceBool(attrs["failover_database"].(string)),
-			GoldenGate:                      database.ServiceInstanceBool(attrs["golden_gate"].(string)),
-			IBKUP:                           database.ServiceInstanceBool(attrs["ibkup"].(string)),
-			IsRAC:                           database.ServiceInstanceBool(attrs["is_rac"].(string)),
-			NCharSet:                        database.ServiceInstanceNCharSet(attrs["n_char_set"].(string)),
-			PDBName:                         attrs["pdb_name"].(string),
-			SID:                             attrs["sid"].(string),
-			Timezone:                        attrs["timezone"].(string),
-			Type:                            database.ServiceInstanceType(attrs["type"].(string)),
-			UsableStorage:                   strconv.Itoa(attrs["usable_storage"].(int)),
+			DisasterRecovery:  client.SwapBoolToString(attrs["disaster_recovery"].(bool)),
+			FailoverDatabase:  client.SwapBoolToString(attrs["failover_database"])
+			GoldenGate:        client.SwapBoolToString(attrs["golden_gate"].(bool)),
+			IsRAC:             client.SwapBoolToString(attrs["is_rac"].(bool)),
+			NCharSet:          database.ServiceInstanceNCharSet(attrs["n_char_set"].(string)),
+			PDBName:           attrs["pdb_name"].(string),
+			SID:               attrs["sid"].(string),
+			Timezone:          attrs["timezone"].(string),
+			Type:              database.ServiceInstanceType(attrs["type"].(string)),
+			UsableStorage:     strconv.Itoa(attrs["usable_storage"].(int)),
 		}
 
-		if val, ok := attrs["cloud_storage_container"].(string); ok && val != "" {
-			parameter.CloudStorageContainer = val
-		}
-		if val, ok := attrs["cloud_storage_username"].(string); ok && val != "" {
-			parameter.CloudStorageUsername = val
-		}
-		if val, ok := attrs["cloud_storage_password"].(string); ok && val != "" {
-			parameter.CloudStoragePassword = val
-		}
-		if val, ok := attrs["ibkup_cloud_storage_username"].(string); ok && val != "" {
-			parameter.IBKUPCloudStorageUser = val
-		}
-		if val, ok := attrs["ibkup_cloud_storage_password"].(string); ok && val != "" {
-			parameter.IBKUPCloudStoragePassword = val
-		}
-		if val, ok := attrs["ibkup_database_id"].(string); ok && val != "" {
-			parameter.IBKUPDatabaseID = val
-		}
-		if val, ok := attrs["ibkup_decryption_key"].(string); ok && val != "" {
-			parameter.IBKUPDecryptionKey = val
-		}
-		if val, ok := attrs["ibkup_wallet_file_content"].(string); ok && val != "" {
-			parameter.IBKUPWalletFileContent = val
-		}
 		if val, ok := attrs["snapshot_name"].(string); ok && val != "" {
 			parameter.SnapshotName = val
 		}
 		if val, ok := attrs["source_service_name"].(string); ok && val != "" {
 			parameter.SourceServiceName = val
 		}
-		if val, ok := attrs["db_demo"].(string); ok && val != "" {
+		if val, ok := attrs["db_demo"].(bool); ok {
 			addParam := database.AdditionalParameters{
-				DBDemo: database.ServiceInstanceBool(val),
+				DBDemo: client.SwapBoolToString(val),
 			}
-			parameter.AdditonalParameters = addParam
+			parameter.AdditionalParameters = addParam
 		}
 	}
+	expandIbkup(d, &parameter)
+	expandCloudStorage(d, &parameter)
 	return []database.Parameter{parameter}
+}
+
+func expandIbkup(d *schema.ResourceData, parameter *database.Parameter) {
+	ibkupInfo := d.Get("ibkup").(*schema.Set)
+	for _, i := range ibkupInfo.List() {
+		attrs := i.(map[string]interface{})
+		parameter.IBKUP = "yes"
+		parameter.IBKUPCloudStorageUser = attrs["cloud_storage_username"].(string)
+		parameter.IBKUPCloudStoragePassword = attrs["cloud_storage_password"].(string)
+		parameter.IBKUPDatabaseID = attrs["database_id"].(string)
+		if val, ok := attrs["decryption_key"].(string); ok && val != "" {
+			parameter.IBKUPDecryptionKey = val
+		}
+		if val, ok := attrs["wallet_file_content"].(string); ok && val != "" {
+			parameter.IBKUPWalletFileContent = val
+		}
+	}
+}
+
+func expandCloudStorage(d *schema.ResourceData, parameter *database.Parameter) {
+	cloudStorageInfo := d.Get("cloud_storage").(*schema.Set)
+	for _, i := range cloudStorageInfo.List() {
+		attrs := i.(map[string]interface{})
+		parameter.CloudStorageContainer = attrs["container"].(string)
+		parameter.CloudStorageUsername = attrs["username"].(string)
+		parameter.CloudStoragePassword = attrs["password"].(string)
+		parameter.CreateStorageContainerIfMissing = attrs["create_if_missing"].(bool)
+	}
 }

--- a/opc/resource_database_service_instance.go
+++ b/opc/resource_database_service_instance.go
@@ -202,17 +202,18 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cloud_storage_password": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							ForceNew:    true,
-							DefaultFunc: schema.EnvDefaultFunc("OPC_PASSWORD", nil),
-							Sensitive:   true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							ForceNew:  true,
+							Sensitive: true,
+							Computed:  true,
 						},
 						"cloud_storage_username": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							ForceNew:    true,
-							DefaultFunc: schema.EnvDefaultFunc("OPC_USERNAME", nil),
+							Type:      schema.TypeString,
+							Optional:  true,
+							ForceNew:  true,
+							Computed:  true,
+							Sensitive: true,
 						},
 						"database_id": {
 							Type:     schema.TypeString,
@@ -245,17 +246,18 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 							ForceNew: true,
 						},
 						"username": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							DefaultFunc: schema.EnvDefaultFunc("OPC_USERNAME", nil),
-							ForceNew:    true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							ForceNew:  true,
+							Computed:  true,
+							Sensitive: true,
 						},
 						"password": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							ForceNew:    true,
-							DefaultFunc: schema.EnvDefaultFunc("OPC_PASSWORD", nil),
-							Sensitive:   true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							ForceNew:  true,
+							Computed:  true,
+							Sensitive: true,
 						},
 						"create_if_missing": {
 							Type:     schema.TypeBool,
@@ -566,9 +568,13 @@ func expandIbkup(d *schema.ResourceData, parameter *database.ParameterInput) {
 	for _, i := range ibkupInfo.List() {
 		attrs := i.(map[string]interface{})
 		parameter.IBKUP = true
-		parameter.IBKUPCloudStorageUser = attrs["cloud_storage_username"].(string)
-		parameter.IBKUPCloudStoragePassword = attrs["cloud_storage_password"].(string)
-		parameter.IBKUPDatabaseID = attrs["database_id"].(string)
+		parameter.IBKUPDatabaseID = attrs["cloud_storage_username"].(string)
+		if val, ok := attrs["decryption_key"].(string); ok && val != "" {
+			parameter.IBKUPCloudStorageUser = val
+		}
+		if val, ok := attrs["cloud_storage_password"].(string); ok && val != "" {
+			parameter.IBKUPCloudStoragePassword = val
+		}
 		if val, ok := attrs["decryption_key"].(string); ok && val != "" {
 			parameter.IBKUPDecryptionKey = val
 		}
@@ -583,8 +589,12 @@ func expandCloudStorage(d *schema.ResourceData, parameter *database.ParameterInp
 	for _, i := range cloudStorageInfo.List() {
 		attrs := i.(map[string]interface{})
 		parameter.CloudStorageContainer = attrs["container"].(string)
-		parameter.CloudStorageUsername = attrs["username"].(string)
-		parameter.CloudStoragePassword = attrs["password"].(string)
 		parameter.CreateStorageContainerIfMissing = attrs["create_if_missing"].(bool)
+		if val, ok := attrs["username"].(string); ok && val != "" {
+			parameter.CloudStorageUsername = val
+		}
+		if val, ok := attrs["password"].(string); ok && val != "" {
+			parameter.CloudStoragePassword = val
+		}
 	}
 }

--- a/opc/resource_database_service_instance.go
+++ b/opc/resource_database_service_instance.go
@@ -249,7 +249,7 @@ func resourceOPCDatabaseServiceInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
-							Default: "ORCL"
+							Default:  "ORCL",
 						},
 						"snapshot_name": {
 							Type:     schema.TypeString,
@@ -437,7 +437,6 @@ func resourceOPCDatabaseServiceInstanceCreate(d *schema.ResourceData, meta inter
 	return resourceOPCDatabaseServiceInstanceRead(d, meta)
 }
 
-// TODO all of this
 func resourceOPCDatabaseServiceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
 	databaseClient := meta.(*OPCClient).databaseClient.ServiceInstanceClient()

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -37,6 +37,27 @@ func TestAccOPCDatabaseServiceInstance_Basic(t *testing.T) {
 	})
 }
 
+func TestAccOPCDatabaseServiceInstance_CloudStorage(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccDatabaseServiceInstanceCloudStorage(ri)
+	resourceName := "opc_database_service_instance.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabaseServiceInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseServiceInstanceExists,
+					resource.TestCheckResourceAttr(
+						resourceName, "cloud_storage_container", fmt.Sprintf("Storage-canonical/matthew-test-%d", ri)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDatabaseServiceInstanceExists(s *terraform.State) error {
 	client := testAccProvider.Meta().(*OPCClient).databaseClient.ServiceInstanceClient()
 

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -57,7 +57,10 @@ func testAccCheckDatabaseServiceInstanceExists(s *terraform.State) error {
 }
 
 func testAccCheckDatabaseServiceInstanceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*OPCClient).databaseClient.ServiceInstanceClient()
+	client := testAccProvider.Meta()
+	if client == nil {
+		return fmt.Errorf("Database Client is not initialized. Make sure to use `database_endpoint` variable or `OPC_DATABASE_ENDPOINT` env variable")
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "opc_database_service_instance" {
@@ -67,7 +70,7 @@ func testAccCheckDatabaseServiceInstanceDestroy(s *terraform.State) error {
 		input := database.GetServiceInstanceInput{
 			Name: rs.Primary.Attributes["name"],
 		}
-		if info, err := client.GetServiceInstance(&input); err == nil {
+		if info, err := client.(*OPCClient).databaseClient.ServiceInstanceClient().GetServiceInstance(&input); err == nil {
 			return fmt.Errorf("DatabaseServiceInstance %s still exists: %#v", input.Name, info)
 		}
 	}

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -117,3 +117,27 @@ func testAccDatabaseServiceInstanceBasic(rInt int) string {
     }
   }`, rInt)
 }
+
+func testAccDatabaseServiceInstanceCloudStorage(rInt int) string {
+	return fmt.Sprintf(`resource "opc_database_service_instance" "test" {
+    name        = "test-service-instance-%d"
+    description = "test service instance"
+    edition = "EE_EP"
+    level = "PAAS"
+    shape = "oc1m"
+    subscription_type = "HOURLY"
+    version = "12.2.0.1"
+    vm_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3QxPp0BFK+ligB9m1FBcFELyvN5EdNUoSwTCe4Zv2b51OIO6wGM/dvTr/yj2ltNA/Vzl9tqf9AUBL8tKjAOk8uukip6G7rfigby+MvoJ9A8N0AC2te3TI+XCfB5Ty2M2OmKJjPOPCd6+OdzhT4cWnPOM+OAiX0DP7WCkO4Kx2kntf8YeTEurTCspOrRjGdo+zZkJxEydMt31asu9zYOTLmZPwLCkhel8vY6SnZhDTNSNkRzxZFv+Mh2VGmqu4SSxfVXr4tcFM6/MbAXlkA8jo+vHpy5sC79T4uNaPu2D8Ed7uC3yDdO3KRVdzZCfWHj4NjixdMs2CtK6EmyeVOPuiYb8/mcTybrb4F/CqA4jydAU6Ok0j0bIqftLyxNgfS31hR1Y3/GNPzly4+uUIgZqmsuVFh5h0L7qc1jMv7wRHphogo5snIp45t9jWNj8uDGzQgWvgbFP5wR7Nt6eS0kaCeGQbxWBDYfjQE801IrwhgMfmdmGw7FFveCH0tFcPm6td/8kMSyg/OewczZN3T62ETQYVsExOxEQl2t4SZ/yqklg+D9oGM+ILTmBRzIQ2m/xMmsbowiTXymjgVmvrWuc638X6dU2fKJ7As4hxs3rA1BA5sOt0XyqfHQhtYrL/Ovb1iV+C7MRhKicTyoNTc7oVcDDG0VW785d8CPqttDi50w=="
+    parameter {
+      admin_password = "Test_String7"
+      backup_destination = "OSS"
+      failover_database = false
+      sid = "ORCL"
+      usable_storage = 15
+    }
+    cloud_storage {
+      container = "Storage-canonical/matthew-test-%d"
+      create_if_missing = true
+    }
+	}`, rInt, rInt)
+}

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -29,6 +29,8 @@ func TestAccOPCDatabaseServiceInstance_Basic(t *testing.T) {
 						resourceName, "edition", "EE_EP"),
 					resource.TestCheckResourceAttr(
 						resourceName, "version", "12.2.0.1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.#", "1"),
 				),
 			},
 		},

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -57,7 +57,7 @@ func testAccCheckDatabaseServiceInstanceExists(s *terraform.State) error {
 }
 
 func testAccCheckDatabaseServiceInstanceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta()
+	client := testAccProvider.Meta().(*OPCClient).databaseClient.ServiceInstanceClient()
 	if client == nil {
 		return fmt.Errorf("Database Client is not initialized. Make sure to use `database_endpoint` variable or `OPC_DATABASE_ENDPOINT` env variable")
 	}
@@ -70,7 +70,7 @@ func testAccCheckDatabaseServiceInstanceDestroy(s *terraform.State) error {
 		input := database.GetServiceInstanceInput{
 			Name: rs.Primary.Attributes["name"],
 		}
-		if info, err := client.(*OPCClient).databaseClient.ServiceInstanceClient().GetServiceInstance(&input); err == nil {
+		if info, err := client.GetServiceInstance(&input); err == nil {
 			return fmt.Errorf("DatabaseServiceInstance %s still exists: %#v", input.Name, info)
 		}
 	}

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -49,7 +49,7 @@ func testAccCheckDatabaseServiceInstanceExists(s *terraform.State) error {
 			Name: rs.Primary.Attributes["name"],
 		}
 		if _, err := client.GetServiceInstance(&input); err != nil {
-			return fmt.Errorf("Error retrieving state of DatabaseServiceInstance %s: %s", input.Name, err)
+			return fmt.Errorf("Error retrieving state of DatabaseServiceInstance %s: %+v", input.Name, err)
 		}
 	}
 

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -1,0 +1,93 @@
+package opc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/database"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOPCDatabaseServiceInstance_Basic(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccDatabaseServiceInstanceBasic(ri)
+	resourceName := "opc_database_service_instance.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabaseServiceInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseServiceInstanceExists,
+					resource.TestCheckResourceAttr(
+						resourceName, "description", "test service instance"),
+					resource.TestCheckResourceAttr(
+						resourceName, "edition", "EE_EP"),
+					resource.TestCheckResourceAttr(
+						resourceName, "version", "12.2.0.1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatabaseServiceInstanceExists(s *terraform.State) error {
+	client := testAccProvider.Meta().(*OPCClient).databaseClient.ServiceInstanceClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opc_database_service_instance" {
+			continue
+		}
+
+		input := database.GetServiceInstanceInput{
+			Name: rs.Primary.Attributes["name"],
+		}
+		if _, err := client.GetServiceInstance(&input); err != nil {
+			return fmt.Errorf("Error retrieving state of DatabaseServiceInstance %s: %s", input.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDatabaseServiceInstanceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*OPCClient).databaseClient.ServiceInstanceClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opc_database_service_instance" {
+			continue
+		}
+
+		input := database.GetServiceInstanceInput{
+			Name: rs.Primary.Attributes["name"],
+		}
+		if info, err := client.GetServiceInstance(&input); err == nil {
+			return fmt.Errorf("DatabaseServiceInstance %s still exists: %#v", input.Name, info)
+		}
+	}
+
+	return nil
+}
+
+func testAccDatabaseServiceInstanceBasic(rInt int) string {
+	return fmt.Sprintf(`resource "opc_database_service_instance" "test" {
+    name        = "test-service-instance-%d"
+    description = "test service instance"
+    edition = "EE_EP"
+    level = "PAAS"
+    shape = "oc1m"
+    subscription_type = "HOURLY"
+    version = "12.2.0.1"
+    vm_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3QxPp0BFK+ligB9m1FBcFELyvN5EdNUoSwTCe4Zv2b51OIO6wGM/dvTr/yj2ltNA/Vzl9tqf9AUBL8tKjAOk8uukip6G7rfigby+MvoJ9A8N0AC2te3TI+XCfB5Ty2M2OmKJjPOPCd6+OdzhT4cWnPOM+OAiX0DP7WCkO4Kx2kntf8YeTEurTCspOrRjGdo+zZkJxEydMt31asu9zYOTLmZPwLCkhel8vY6SnZhDTNSNkRzxZFv+Mh2VGmqu4SSxfVXr4tcFM6/MbAXlkA8jo+vHpy5sC79T4uNaPu2D8Ed7uC3yDdO3KRVdzZCfWHj4NjixdMs2CtK6EmyeVOPuiYb8/mcTybrb4F/CqA4jydAU6Ok0j0bIqftLyxNgfS31hR1Y3/GNPzly4+uUIgZqmsuVFh5h0L7qc1jMv7wRHphogo5snIp45t9jWNj8uDGzQgWvgbFP5wR7Nt6eS0kaCeGQbxWBDYfjQE801IrwhgMfmdmGw7FFveCH0tFcPm6td/8kMSyg/OewczZN3T62ETQYVsExOxEQl2t4SZ/yqklg+D9oGM+ILTmBRzIQ2m/xMmsbowiTXymjgVmvrWuc638X6dU2fKJ7As4hxs3rA1BA5sOt0XyqfHQhtYrL/Ovb1iV+C7MRhKicTyoNTc7oVcDDG0VW785d8CPqttDi50w=="
+    parameter {
+      admin_password = "Test_String7"
+      backup_destination = "NONE"
+      sid = "ORCL"
+      usable_storage = 15
+    }
+  }`, rInt)
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/client/client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/client/client.go
@@ -95,12 +95,28 @@ func (c *Client) BuildRequest(method, path string, body interface{}) (*http.Requ
 	return req, nil
 }
 
+// Build a new HTTP request that doesn't marshall the request body
+func (c *Client) BuildNonJSONRequest(method, path string, body io.ReadSeeker) (*http.Request, error) {
+	// Parse URL Path
+	urlPath, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create request
+	req, err := http.NewRequest(method, c.formatURL(urlPath), body)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // This method executes the http.Request from the BuildRequest method.
 // It is split up to add additional authentication that is Oracle API dependent.
 func (c *Client) ExecuteRequest(req *http.Request) (*http.Response, error) {
 	// Execute request with supplied client
 	resp, err := c.retryRequest(req)
-	//resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/compute/storage_volumes.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/compute/storage_volumes.go
@@ -35,6 +35,7 @@ type StorageVolumeKind string
 const (
 	StorageVolumeKindDefault StorageVolumeKind = "/oracle/public/storage/default"
 	StorageVolumeKindLatency StorageVolumeKind = "/oracle/public/storage/latency"
+	StorageVolumeKindSSD     StorageVolumeKind = "/oracle/public/storage/ssd/gp1"
 )
 
 // StorageVolumeInfo represents information retrieved from the service about a Storage Volume.

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/authentication.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/authentication.go
@@ -1,0 +1,13 @@
+package database
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// Get a new auth token for the storage client
+func (c *DatabaseClient) getAuthenticationHeader() *string {
+	usernamePassword := []byte(fmt.Sprintf("%s:%s", *c.client.UserName, *c.client.Password))
+	authToken := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString(usernamePassword))
+	return &authToken
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/database_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/database_client.go
@@ -1,0 +1,105 @@
+package database
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-oracle-terraform/client"
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+const DB_ACCOUNT = "/Database-%s"
+const DB_USERNAME = "/Database-%s:%s"
+const AUTH_HEADER = "Authorization"
+const TENANT_HEADER = "X-ID-TENANT-NAME"
+const DB_QUALIFIED_NAME = "%s%s/%s"
+
+// Client represents an authenticated database client, with compute credentials and an api client.
+type DatabaseClient struct {
+	client     *client.Client
+	authHeader *string
+}
+
+func NewDatabaseClient(c *opc.Config) (*DatabaseClient, error) {
+	databaseClient := &DatabaseClient{}
+	client, err := client.NewClient(c)
+	if err != nil {
+		return nil, err
+	}
+	databaseClient.client = client
+
+	databaseClient.authHeader = databaseClient.getAuthenticationHeader()
+
+	return databaseClient, nil
+}
+
+func (c *DatabaseClient) executeRequest(method, path string, body interface{}) (*http.Response, error) {
+	req, err := c.client.BuildRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	debugReqString := fmt.Sprintf("HTTP %s Req (%s)", method, path)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	// Log the request before the authentication header, so as not to leak credentials
+	c.client.DebugLogString(debugReqString)
+
+	// Set the authentiation headers
+	req.Header.Add(AUTH_HEADER, *c.authHeader)
+	req.Header.Add(TENANT_HEADER, *c.client.IdentityDomain)
+	c.client.DebugLogString(fmt.Sprintf("Req (%+v)", req))
+	resp, err := c.client.ExecuteRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *DatabaseClient) getUserName() string {
+	return fmt.Sprintf(DB_USERNAME, *c.client.IdentityDomain, *c.client.UserName)
+}
+
+func (c *DatabaseClient) getAccount() string {
+	return fmt.Sprintf(DB_ACCOUNT, *c.client.IdentityDomain)
+}
+
+// GetQualifiedName returns the fully-qualified name of a database object, e.g. /v1/{account}/{name}
+func (c *DatabaseClient) getQualifiedName(version string, name string) string {
+	if name == "" {
+		return ""
+	}
+	if strings.HasPrefix(name, "/Database-") || strings.HasPrefix(name, "v1/") {
+		return name
+	}
+	return fmt.Sprintf(DB_QUALIFIED_NAME, version, c.getAccount(), name)
+}
+
+// GetUnqualifiedName returns the unqualified name of a Database object, e.g. the {name} part of /v1/{account}/{name}
+func (c *DatabaseClient) getUnqualifiedName(name string) string {
+	if name == "" {
+		return name
+	}
+	if !strings.Contains(name, "/") {
+		return name
+	}
+
+	nameParts := strings.Split(name, "/")
+	return strings.Join(nameParts[len(nameParts)-1:], "/")
+}
+
+func (c *DatabaseClient) unqualify(names ...*string) {
+	for _, name := range names {
+		*name = c.getUnqualifiedName(*name)
+	}
+}
+
+func (c *DatabaseClient) getContainerPath(root string) string {
+	return fmt.Sprintf(root, *c.client.IdentityDomain)
+}
+
+func (c *DatabaseClient) getObjectPath(root, name string) string {
+	return fmt.Sprintf(root, *c.client.IdentityDomain, name)
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/database_resource_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/database_resource_client.go
@@ -49,14 +49,14 @@ func (c *ResourceClient) getResource(name string, responseBody interface{}) erro
 	return c.unmarshalResponseBody(resp, responseBody)
 }
 
-func (c *ResourceClient) deleteResource(name string) error {
+func (c *ResourceClient) deleteResource(name string, body interface{}) error {
 	var objectPath string
 	if name != "" {
 		objectPath = c.getObjectPath(c.ResourceRootPath, name)
 	} else {
 		objectPath = c.ResourceRootPath
 	}
-	_, err := c.executeRequest("DELETE", objectPath, nil)
+	_, err := c.executeRequest("DELETE", objectPath, body)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/database_resource_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/database_resource_client.go
@@ -1,0 +1,94 @@
+package database
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// ResourceClient is an AuthenticatedClient with some additional information about the resources to be addressed.
+type ResourceClient struct {
+	*DatabaseClient
+	ContainerPath    string
+	ResourceRootPath string
+}
+
+func (c *ResourceClient) createResource(requestBody interface{}, responseBody interface{}) error {
+	_, err := c.executeRequest("POST", c.getContainerPath(c.ContainerPath), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *ResourceClient) updateResource(name string, requestBody interface{}, responseBody interface{}) error {
+	_, err := c.executeRequest("PUT", c.getObjectPath(c.ResourceRootPath, name), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *ResourceClient) getResource(name string, responseBody interface{}) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.ResourceRootPath
+	}
+	resp, err := c.executeRequest("GET", objectPath, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.unmarshalResponseBody(resp, responseBody)
+}
+
+func (c *ResourceClient) deleteResource(name string) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.ResourceRootPath
+	}
+	_, err := c.executeRequest("DELETE", objectPath, nil)
+	if err != nil {
+		return err
+	}
+
+	// No errors and no response body to write
+	return nil
+}
+
+func (c *ResourceClient) unmarshalResponseBody(resp *http.Response, iface interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	c.client.DebugLogString(fmt.Sprintf("HTTP Resp (%d): %s", resp.StatusCode, buf.String()))
+	// JSON decode response into interface
+	var tmp interface{}
+	dcd := json.NewDecoder(buf)
+	if err := dcd.Decode(&tmp); err != nil {
+		return fmt.Errorf("%+v", resp)
+		return err
+	}
+
+	// Use mapstructure to weakly decode into the resulting interface
+	msdcd, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           iface,
+		TagName:          "json",
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := msdcd.Decode(tmp); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
@@ -1,0 +1,592 @@
+package database
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-oracle-terraform/client"
+)
+
+const WaitForServiceInstanceReadyTimeout = time.Duration(3600 * time.Second)
+const WaitForServiceInstanceDeleteTimeout = time.Duration(3600 * time.Second)
+const ServiceInstanceDeleteRetry = 30
+
+var (
+	ServiceInstanceContainerPath = "/paas/service/dbcs/api/v1.1/instances/%s"
+	ServiceInstanceResourcePath  = "/paas/service/dbcs/api/v1.1/instances/%s/%s"
+)
+
+// ServiceInstanceClient is a client for the Service functions of the Database API.
+type ServiceInstanceClient struct {
+	ResourceClient
+	Timeout time.Duration
+}
+
+// ServiceInstanceClient obtains an ServiceInstanceClient which can be used to access to the
+// Service Instance functions of the Database Cloud API
+func (c *DatabaseClient) ServiceInstanceClient() *ServiceInstanceClient {
+	return &ServiceInstanceClient{
+		ResourceClient: ResourceClient{
+			DatabaseClient:   c,
+			ContainerPath:    ServiceInstanceContainerPath,
+			ResourceRootPath: ServiceInstanceResourcePath,
+		}}
+}
+
+type ServiceInstanceEdition string
+
+const (
+	// SE: Standard Edition
+	ServiceInstanceStandardEdition ServiceInstanceEdition = "SE"
+	// EE: Enterprise Edition
+	ServiceInstanceEnterpriseEdition ServiceInstanceEdition = "EE"
+	// EE_HP: Enterprise Edition - High Performance
+	ServiceInstanceEnterpriseEditionHighPerformance ServiceInstanceEdition = "EE_HP"
+	// EE_EP: Enterprise Edition - Extreme Performance
+	ServiceInstanceEnterpriseEditionExtremePerformance ServiceInstanceEdition = "EE_EP"
+)
+
+type ServiceInstanceLevel string
+
+const (
+	// PAAS: The Oracle Database Cloud Service service level
+	ServiceInstanceLevelPAAS ServiceInstanceLevel = "PAAS"
+	// BASIC: The Oracle Database Cloud Service - Virtual Image service level
+	ServiceInstanceLevelBasic ServiceInstanceLevel = "BASIC"
+)
+
+type ServiceInstanceBool string
+
+const (
+	ServiceInstanceYes ServiceInstanceBool = "yes"
+	ServiceInstanceNo  ServiceInstanceBool = "no"
+)
+
+type ServiceInstanceBackupDestination string
+
+const (
+	// BOTH - Both Cloud Storage and Local Storage
+	ServiceInstanceBackupDestinationBoth ServiceInstanceBackupDestination = "BOTH"
+	// OSS - Cloud Storage only
+	ServiceInstanceBackupDestinationOSS ServiceInstanceBackupDestination = "OSS"
+	// NONE - None
+	ServiceInstanceBackupDestinationNone ServiceInstanceBackupDestination = "NONE"
+)
+
+type ServiceInstanceNCharSet string
+
+const (
+	ServiceInstanceNCharSetUTF16 ServiceInstanceNCharSet = "AL16UTF16"
+	ServiceInstanceNCharSetUTF8  ServiceInstanceNCharSet = "UTF8"
+)
+
+type ServiceInstanceType string
+
+const (
+	ServiceInstanceTypeDB ServiceInstanceType = "db"
+)
+
+type ServiceInstanceShape string
+
+const (
+	// oc3: 1 OCPU, 7.5 GB memory
+	ServiceInstanceShapeOC3 ServiceInstanceShape = "oc3"
+	// oc4: 2 OCPUs, 15 GB memory
+	ServiceInstanceShapeOC4 ServiceInstanceShape = "oc4"
+	// oc5: 4 OCPUs, 30 GB memory
+	ServiceInstanceShapeOC5 ServiceInstanceShape = "oc5"
+	// oc6: 8 OCPUs, 15 GB memory
+	ServiceInstanceShapeOC6 ServiceInstanceShape = "oc6"
+	// oc1m: 1 OCPU, 15 GB memory
+	ServiceInstanceShapeOC1M ServiceInstanceShape = "oc1m"
+	// oc2m: 2 OCPUs, 30 GB memory
+	ServiceInstanceShapeOC2M ServiceInstanceShape = "oc2m"
+	// oc3m: 4 OCPUs, 60 GB memory
+	ServiceInstanceShapeOC3M ServiceInstanceShape = "oc3m"
+	// oc4m: 8 OCPUs, 120 GB memory
+	ServiceInstanceShapeOC4M ServiceInstanceShape = "oc4m"
+)
+
+type ServiceInstanceSubscriptionType string
+
+const (
+	ServiceInstanceSubscriptionTypeHourly  ServiceInstanceSubscriptionType = "HOURLY"
+	ServiceInstanceSubscriptionTypeMonthly ServiceInstanceSubscriptionType = "MONTHLY"
+)
+
+type ServiceInstanceVersion string
+
+const (
+	// 12.2.0.1
+	ServiceInstanceVersion12201 ServiceInstanceVersion = "12.2.0.1"
+	// 12.1.0.2
+	ServiceInstanceVersion12102 ServiceInstanceVersion = "12.1.0.2"
+	// 11.2.0.4
+	ServiceInstanceVersion11204 ServiceInstanceVersion = "11.2.0.4"
+)
+
+type ServiceInstanceState string
+
+const (
+	// 	Configured: the service instance has been configured.
+	ServiceInstanceConfigured ServiceInstanceState = "Configured"
+	//	In Progress: the service instance is being created.
+	ServiceInstanceInProgress ServiceInstanceState = "In Progress"
+	//	Maintenance: the service instance is being stopped, started, restarted or scaled.
+	ServiceInstanceMaintenance ServiceInstanceState = "Maintenance"
+	//	Running: the service instance is running.
+	ServiceInstanceRunning ServiceInstanceState = "Running"
+	//	Stopped: the service instance is stopped.
+	ServiceInstanceStopped ServiceInstanceState = "Stopped"
+	//	Terminating: the service instance is being deleted.
+	ServiceInstanceTerminating ServiceInstanceState = "Terminating"
+)
+
+type ServiceInstance struct {
+	// The URL to use to connect to Oracle Application Express on the service instance.
+	ApexURL string `json:"apex_url"`
+	// The backup configuration of the service instance.
+	BackupDestination string `json:"backup_destination"`
+	// The version of cloud tooling for backup and recovery supported by the service instance.
+	BackupSupportedVersion string `backup_supported_version`
+	// The database character set of the database.
+	CharSet string `json:"charset"`
+	// The Oracle Storage Cloud container for backups.
+	CloudStorageContainer string `json:"cloud_storage_container"`
+	// The Oracle Cloud location housing the service instance.
+	ComputeSiteName string `json:"compute_site_name"`
+	// The connection descriptor for Oracle Net Services (SQL*Net).
+	ConnectDescriptor string `json:"connect_descriptor"`
+	// The connection descriptor for Oracle Net Services (SQL*Net) with IP addresses instead of host names.
+	ConnectorDescriptorWithPublicIP string `json:"connect_descriptor_with_public_ip"`
+	// The user name of the Oracle Cloud user who created the service instance.
+	CreatedBy string `json:"created_by"`
+	// The job id of the job that created the service instance.
+	CreationJobID string `json:"creation_job_id"`
+	// The date-and-time stamp when the service instance was created.
+	CreationTime string `json:"creation_time"`
+	// The Oracle Database version on the service instance, including the patch level.
+	CurrentVersion string `json:"current_version"`
+	// The URL to use to connect to Oracle DBaaS Monitor on the service instance.
+	DBAASMonitorURL string `json:"dbaasmonitor_url"`
+	// The description of the service instance, if one was provided when the instance was created.
+	Description string `json:"description"`
+	// The software edition of the service instance.
+	Edition ServiceInstanceEdition `json:"edition"`
+	// The URL to use to connect to Enterprise Manager on the service instance.
+	EMURL string `json:"em_url"`
+	// Indicates whether the service instance hosts an Oracle Data Guard configuration.
+	FailoverDatabase bool `json:"failover_database"`
+	// The URL to use to connect to the Oracle GlassFish Server Administration Console on the service instance.
+	GlassFishURL string `json:"glassfish_url"`
+	// Data Guard Role of the on-premise instance in Oracle Hybrid Disaster Recovery configuration.
+	HDGPremIP string `json:"hdgPremIP"`
+	// Indicates whether the service instance hosts an Oracle Hybrid Disaster Recovery configuration.
+	HybridDG string `json:"hybrid_db"`
+	// The identity domain housing the service instance.
+	IdentityDomain string `json:"identity_domain"`
+	// This attribute is only applicable to accounts where regions are supported.
+	// The three-part name of an IP network to which the service instance is added.
+	// For example: /Compute-identity_domain/user/object
+	IPNetwork string `json:"ipNetwork"`
+	// Groups one or more IP reservations in use on this service instance.
+	// This attribute is only applicable to accounts where regions are supported.
+	// This attribute is returned when you set the ?outputLevel=verbose query parameter.
+	IPReservations string `json:"ipReservations"`
+	// The Oracle Java Cloud Service instances using this Database Cloud Service instance.
+	JAASInstancesUsingService string `json:"jaas_instances_using_service"`
+	// The date-and-time stamp when the service instance was last modified.
+	LastModifiedTime string `json:"last_modified_time"`
+	// The service level of the service instance.
+	Level ServiceInstanceLevel `json:"level"`
+	// The listener port for Oracle Net Services (SQL*Net) connections.
+	ListenerPort int `json:"listener_port"`
+	// The national character set of the database.
+	NCharSet string `json:"ncharset"`
+	// The number of Oracle Compute Service IP reservations assigned to the service instance.
+	NumIPReservations int `json:"num_ip_reservations"`
+	// The number of compute nodes in the service instance.
+	NumNodes string `json:"num_nodes"`
+	// The name of the default PDB (pluggable database) created when the service instance was created.
+	PDBName string `json:"pdbName"`
+	// Indicates whether the service instance hosts an Oracle RAC database.
+	RACDatabase bool `json:"rac_database"`
+	// This attribute is only applicable to accounts where regions are supported.
+	// Location where the service instance is provisioned (only for accounts where regions are supported).
+	Region string `json:"region"`
+	// The name of the service instance.
+	Name string `json:"service_name"`
+	// The REST endpoint URI of the service instance.
+	URI string `json:"service_uri"`
+	// The Oracle Compute Cloud shape of the service instance.
+	Shape string `json:"shape"`
+	// The SID of the database.
+	SID string `json:"sid"`
+	// The version of the cloud tooling service manager plugin supported by the service instance.
+	SMPluginVersion string `json:"sm_plugin_version"`
+	// The status of the service instance
+	Status ServiceInstanceState `json:"status"`
+	// The billing frequency of the service instance; either MONTHLY or HOURLY.
+	SubscriptionType ServiceInstanceSubscriptionType `json:"subscriptionType"`
+	// The time zone of the operating system.
+	Timezone string `json:"timezone"`
+	// For service instances hosting an Oracle RAC database, the size in GB of the storage shared
+	// and accessed by the nodes of the RAC database.
+	TotalSharedStorage int `json:"total_shared_storage"`
+	// The Oracle Database version on the service instance.
+	Version string `json:"version"`
+}
+
+type CreateServiceInstanceInput struct {
+	// Free-form text that provides additional information about the service instance.
+	// Optional.
+	Description string `json:"description,omitempty"`
+	// Database edition for the service instance:
+	// If you specify SE, a Standard Edition 2 database is created if you specify 12.2.0.1 or 12.1.0.2
+	// for version and a Standard Edition One database is created if you specify 11.2.0.4 for version.
+	// Edition must be Enterprise Edition - Extreme Performance to configure the Database
+	// Cloud Service instance as Cluster Database.
+	// Required.
+	Edition ServiceInstanceEdition `json:"edition"`
+	// Service level for the service instance
+	// Required.
+	Level ServiceInstanceLevel `json:"level"`
+	// Array of one JSON object that specifies configuration details of the services instance.
+	// This array is not required if the level value is BASIC.
+	// Required if level value is PAAS.
+	Parameters []Parameter `json:"parameters,omitempty"`
+	// Name of Database Cloud Service instance. The service name:
+	// Must not exceed 50 characters.
+	// Must start with a letter.
+	// Must contain only letters, numbers, or hyphens.
+	// Must not contain any other special characters.
+	// Must be unique within the identity domain.
+	// Required.
+	Name string `json:"serviceName"`
+	// Desired compute shape. A shape defines the number of Oracle Compute Units (OCPUs) and amount
+	// of memory (RAM).
+	// Required.
+	Shape ServiceInstanceShape `json:"shape"`
+	// Billing unit. Valid values are:
+	// HOURLY: Pay only for the number of hours used during your billing period. This is the default.
+	// MONTHLY: Pay one price for the full month irrespective of the number of hours used.
+	// Required.
+	SubscriptionType ServiceInstanceSubscriptionType `json:"subscriptionType"`
+	// Oracle Database software version
+	// Required.
+	Version ServiceInstanceVersion `json:"version"`
+	// Public key for the secure shell (SSH). This key will be used for authentication when
+	// connecting to the Database Cloud Service instance using an SSH client. You generate an
+	// SSH public-private key pair using a standard SSH key generation tool. See Connecting to
+	// a Compute Node Through Secure Shell (SSH) in Using Oracle Database Cloud Service.
+	// Required.
+	VMPublicKey string `json:"vmPublicKeyText"`
+}
+
+type Parameter struct {
+	AdditonalParameters AdditionalParameters `json:"additionalParams,omitempty"`
+	// Password for Oracle Database administrator users sys and system. The password must meet the following requirements:
+	// Starts with a letter
+	// Is between 8 and 30 characters long
+	// Contains letters, at least one number, and optionally, any number of these special characters: dollar sign ($), pound sign (#), and underscore (_).
+	// Required
+	AdminPassword string `json:"adminPassword"`
+	//Backup destination.
+	// Required
+	BackupDestination ServiceInstanceBackupDestination `json:"backupDestination"`
+	// Character Set for the Database Cloud Service Instance.
+	// Valid values are AL32UTF8, AR8ADOS710, AR8ADOS720, AR8APTEC715, AR8ARABICMACS,
+	// AR8ASMO8X, AR8ISO8859P6, AR8MSWIN1256, AR8MUSSAD768, AR8NAFITHA711, AR8NAFITHA721,
+	// AR8SAKHR706, AR8SAKHR707, AZ8ISO8859P9E, BG8MSWIN, BG8PC437S, BLT8CP921, BLT8ISO8859P13,
+	// BLT8MSWIN1257, BLT8PC775, BN8BSCII, CDN8PC863, CEL8ISO8859P14, CL8ISO8859P5, CL8ISOIR111,
+	// CL8KOI8R, CL8KOI8U, CL8MACCYRILLICS, CL8MSWIN1251, EE8ISO8859P2, EE8MACCES, EE8MACCROATIANS,
+	// EE8MSWIN1250, EE8PC852, EL8DEC, EL8ISO8859P7, EL8MACGREEKS, EL8MSWIN1253, EL8PC437S, EL8PC851,
+	// EL8PC869, ET8MSWIN923, HU8ABMOD, HU8CWI2, IN8ISCII, IS8PC861, IW8ISO8859P8, IW8MACHEBREWS,
+	// IW8MSWIN1255, IW8PC1507, JA16EUC, JA16EUCTILDE, JA16SJIS, JA16SJISTILDE, JA16VMS, KO16KSC5601,
+	// KO16KSCCS, KO16MSWIN949, LA8ISO6937, LA8PASSPORT, LT8MSWIN921, LT8PC772, LT8PC774, LV8PC1117,
+	// LV8PC8LR, LV8RST104090, N8PC865, NE8ISO8859P10, NEE8ISO8859P4, RU8BESTA, RU8PC855, RU8PC866,
+	// SE8ISO8859P3, TH8MACTHAIS, TH8TISASCII, TR8DEC, TR8MACTURKISHS, TR8MSWIN1254, TR8PC857, US7ASCII,
+	// US8PC437, UTF8, VN8MSWIN1258, VN8VN3, WE8DEC, WE8DG, WE8ISO8859P1, WE8ISO8859P15, WE8ISO8859P9,
+	// WE8MACROMAN8S, WE8MSWIN1252, WE8NCR4970, WE8NEXTSTEP, WE8PC850, WE8PC858, WE8PC860, WE8ROMAN8,
+	// ZHS16CGB231280, ZHS16GBK, ZHT16BIG5, ZHT16CCDC, ZHT16DBT, ZHT16HKSCS, ZHT16MSWIN950, ZHT32EUC,
+	// ZHT32SOPS, ZHT32TRIS.
+	// Default value is AL32UTF8.
+	// Optional.
+	CharSet string `json:"charset,omitempty"`
+	// Name of the Oracle Storage Cloud Service container used to provide storage for your service
+	// instance backups. Use the following format to specify the container name:
+	// <storageservicename>-<storageidentitydomain>/<containername>
+	// Notes:
+	// An Oracle Storage Cloud Service container is not required when provisioning a Database
+	// Cloud Service - Virtual Image instance.
+	// Do not use an Oracle Storage Cloud container that you use to back up Database Cloud Service
+	// instances for any other purpose. For example, do not also use it to back up Oracle Java Cloud
+	// Service instances. Using the container for multiple purposes can result in billing errors.
+	// Optional.
+	CloudStorageContainer string `json:"cloudStorageContainer,omitempty"`
+	// Password for the Oracle Storage Cloud Service administrator.
+	// Optional.
+	CloudStoragePassword string `json:"cloudStoragePwd,omitempty"`
+	// Username for the Oracle Storage Cloud Service administrator.
+	// Optional.
+	CloudStorageUsername string `json:"cloudStorageUser,omitempty"`
+	// Specify if the given cloudStorageContainer is to be created if it does not already exist.
+	// Default value is false.
+	// Optional.
+	CreateStorageContainerIfMissing bool `json:"createStorageContainerIfMissing,omitempty"`
+	// Specify if an Oracle Data Guard configuration is created using the Disaster Recovery option
+	// or the High Availability option. Valid values are yes and no:
+	// yes - The Disaster Recovery option is used, which places the compute node hosting the primary
+	// database and the compute node hosting the standby database in compute zones of different data centers.
+	// no - The High Availability option is used, which places the compute node hosting the primary
+	// database and the compute node hosting the standby database in different compute zones of the same
+	// data center.
+	// Default value is no.
+	// This option is applicable only when failoverDatabase is set to yes.
+	// Optional
+	DisasterRecovery ServiceInstanceBool `json:"disasterRecovery,omitempty"`
+	// Specify if an Oracle Data Guard configuration comprising a primary database and a
+	// standby database is created. Valid values are yes and no. Default value is no.
+	// You cannot set both failoverDatabase and isRac to yes.
+	// Optional
+	FailoverDatabase ServiceInstanceBool `json:"failoverDatabase,omitempty"`
+	// Specify if the database should be configured for use as the replication database of an
+	// Oracle GoldenGate Cloud Service instance. Valid values are yes and no. Default value is no.
+	// You cannot set goldenGate to yes if either isRac or failoverDatabase is set to yes.
+	// Optional
+	GoldenGate ServiceInstanceBool `json:"goldenGate,omitempty"`
+	// Specify if the service instance's database should, after the instance is created, be replaced
+	// by a database stored in an existing cloud backup that was created using Oracle Database Backup
+	// Cloud Service. Valid values are yes and no. Default value is no.
+	// Optional
+	IBKUP ServiceInstanceBool `json:"ibkup,omitempty"`
+	// Name of the Oracle Storage Cloud Service container where the existing cloud backup is stored.
+	// This parameter is required if ibkup is set to yes.
+	IBKUPCloudStoragePassword string `json:"ibkupCloudStoragePassword,omitempty"`
+	// User name of an Oracle Cloud user who has read access to the container specified in
+	// ibkupCloudStorageContainer.
+	// This parameter is required if ibkup is set to yes.
+	IBKUPCloudStorageUser string `json:"ibkupCloudStorageUser,omitempty"`
+	// Database id of the database from which the existing cloud backup was created.
+	// This parameter is required if ibkup is set to yes.
+	IBKUPDatabaseID string `json:"ibkupDatabaseID,omitempty"`
+	// Password used to create the existing, password-encrypted cloud backup.
+	// This password is used to decrypt the backup.
+	// This parameter is required if ibkup is set to yes.
+	IBKUPDecryptionKey string `json:"ibkupDecryptionKey,omitempty"`
+	// String containing the xsd:base64Binary representation of the cloud backup's wallet archive file.
+	// Optional
+	IBKUPWalletFileContent string `json:"ibkupWalletFileContent,omitempty"`
+	// Specify if a cluster database using Oracle Real Application Clusters should be configured.
+	// Valid values are yes and no. Default value is no.
+	// Optional
+	IsRAC ServiceInstanceBool `json:"isRac,omitempty"`
+	// National Character Set for the Database Cloud Service instance.
+	// Default value is AL16UTF16.
+	// Optional.
+	NCharSet ServiceInstanceNCharSet `json:"ncharset,omitempty"`
+	// Note: This attribute is valid when Database Cloud Service instance is configured with version 12c.
+	// Pluggable Database Name for the Database Cloud Service instance.
+	// Default value is pdb1.
+	// Optional.
+	PDBName string `json:"pdbName,omitempty"`
+	// Database Name (sid) for the Database Cloud Service instance.
+	// Default value is ORCL.
+	// Required.
+	SID string `json:"sid"`
+	// The name of the snapshot of the service instance specified by sourceServiceName
+	// that is to be used to create a "snapshot clone".
+	// This parameter is valid only if sourceServiceName is specified.
+	// Optional.
+	SnapshotName string `json:"snapshotName,omitempty"`
+	// When present, indicates that the service instance should be created as a
+	// "snapshot clone" of another service instance. Provide the name of the existing service
+	// instance whose snapshot is to be used.
+	// Optional.
+	SourceServiceName string `json:"sourceServiceName,omitempty"`
+	// Time Zone for the Database Cloud Service instance.
+	// Valid values are Africa/Cairo, Africa/Casablanca, Africa/Harare, Africa/Monrovia,
+	// Africa/Nairobi, Africa/Tripoli, Africa/Windhoek, America/Araguaina, America/Asuncion,
+	// America/Bogota, America/Caracas, America/Chihuahua, America/Cuiaba, America/Denver,
+	// America/Fortaleza, America/Guatemala, America/Halifax, America/Manaus, America/Matamoros,
+	// America/Monterrey, America/Montevideo, America/Phoenix, America/Santiago, America/Tijuana,
+	// Asia/Amman, Asia/Ashgabat, Asia/Baghdad, Asia/Baku, Asia/Bangkok, Asia/Beirut, Asia/Calcutta,
+	// Asia/Damascus, Asia/Dhaka, Asia/Irkutsk, Asia/Jerusalem, Asia/Kabul, Asia/Karachi,
+	// Asia/Kathmandu, Asia/Krasnoyarsk, Asia/Magadan, Asia/Muscat, Asia/Novosibirsk, Asia/Riyadh,
+	// Asia/Seoul, Asia/Shanghai, Asia/Singapore, Asia/Taipei, Asia/Tehran, Asia/Tokyo, Asia/Ulaanbaatar,
+	// Asia/Vladivostok, Asia/Yakutsk, Asia/Yerevan, Atlantic/Azores, Australia/Adelaide,
+	// Australia/Brisbane, Australia/Darwin, Australia/Hobart, Australia/Perth, Australia/Sydney,
+	// Brazil/East, Canada/Newfoundland, Canada/Saskatchewan, Europe/Amsterdam, Europe/Athens,
+	// Europe/Dublin, Europe/Helsinki, Europe/Istanbul, Europe/Kaliningrad, Europe/Moscow,
+	// Europe/Paris, Europe/Prague, Europe/Sarajevo, Pacific/Auckland, Pacific/Fiji, Pacific/Guam,
+	// Pacific/Honolulu, Pacific/Samoa, US/Alaska, US/Central, US/Eastern, US/East-Indiana,
+	// US/Pacific, UTC.
+	// Default value is UTC.
+	// Optional.
+	Timezone string `json:"timezone,omitempty"`
+	// Component type to which the set of parameters applies.
+	// Valid values are: db - Oracle Database
+	// Required.
+	Type ServiceInstanceType `json:"type"`
+	// Storage size for data (in GB). Minimum value is 15. Maximum value depends on the backup
+	// destination: if BOTH is specified, the maximum value is 1200; if OSS or NONE is specified,
+	// the maximum value is 2048.
+	// Required.
+	UsableStorage string `json:"usableStorage"`
+}
+
+type AdditionalParameters struct {
+	// Indicates whether to include the Demos PDB
+	// Optional
+	DBDemo ServiceInstanceBool `json:"db_demo,omitempty"`
+}
+
+// CreateServiceInstance creates a new ServiceInstace.
+func (c *ServiceInstanceClient) CreateServiceInstance(input *CreateServiceInstanceInput) (*ServiceInstance, error) {
+	var (
+		serviceInstance      *ServiceInstance
+		serviceInstanceError error
+	)
+	if c.Timeout == 0 {
+		c.Timeout = WaitForServiceInstanceReadyTimeout
+	}
+	// return nil, fmt.Errorf("%+v", input)
+	for i := 0; i < *c.DatabaseClient.client.MaxRetries; i++ {
+		c.client.DebugLogString(fmt.Sprintf("(Iteration: %d of %d) Creating service instance with name %s\n Input: %+v", i, *c.DatabaseClient.client.MaxRetries, input.Name, input))
+
+		serviceInstance, serviceInstanceError = c.startServiceInstance(input.Name, input)
+		if serviceInstanceError == nil {
+			c.client.DebugLogString(fmt.Sprintf("(Iteration: %d of %d) Finished creating service instance with name %s\n Info: %+v", i, *c.DatabaseClient.client.MaxRetries, input.Name, serviceInstance))
+			return serviceInstance, nil
+		}
+	}
+	return nil, serviceInstanceError
+}
+
+func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateServiceInstanceInput) (*ServiceInstance, error) {
+	if err := c.createResource(*input, nil); err != nil {
+		return nil, err
+	}
+
+	// Call wait for instance ready now, as creating the instance is an eventually consistent operation
+	getInput := &GetServiceInstanceInput{
+		Name: name,
+	}
+
+	// Wait for the service instance to be running and return the result
+	// Don't have to unqualify any objects, as the GetServiceInstance method will handle that
+	serviceInstance, serviceInstanceError := c.WaitForServiceInstanceRunning(getInput, c.Timeout)
+	// If the service instance enters an error state we need to delete the instance and retry
+	if serviceInstanceError != nil {
+		deleteInput := &DeleteServiceInstanceInput{
+			Name: name,
+		}
+		err := c.DeleteServiceInstance(deleteInput)
+		if err != nil {
+			return nil, fmt.Errorf("Error deleting service instance %s: %s", name, err)
+		}
+		return nil, serviceInstanceError
+	}
+	return serviceInstance, nil
+}
+
+// WaitForServiceInstanceRunning waits for a service instance to be completely initialized and available.
+func (c *ServiceInstanceClient) WaitForServiceInstanceRunning(input *GetServiceInstanceInput, timeoutSeconds time.Duration) (*ServiceInstance, error) {
+	var info *ServiceInstance
+	var getErr error
+	err := c.client.WaitFor("service instance to be ready", timeoutSeconds, func() (bool, error) {
+		info, getErr = c.GetServiceInstance(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		c.client.DebugLogString(fmt.Sprintf("Service instance name is %v, Service instance info is %+v", info.Name, info))
+		switch s := info.Status; s {
+		case ServiceInstanceRunning: // Target State
+			c.client.DebugLogString("Service Instance Running")
+			return false, nil
+		case ServiceInstanceConfigured:
+			c.client.DebugLogString("Service Instance Configured")
+			return true, nil
+		case ServiceInstanceInProgress:
+			c.client.DebugLogString("Service Instance is being created")
+			return false, nil
+		default:
+			c.client.DebugLogString(fmt.Sprintf("Unknown instance state: %s, waiting", s))
+			return false, nil
+		}
+	})
+	return info, err
+}
+
+type GetServiceInstanceInput struct {
+	// Name of the Database Cloud Service instance.
+	// Required.
+	Name string `json:"serviceId"`
+}
+
+// GetServiceInstance retrieves the SeriveInstance with the given name.
+func (c *ServiceInstanceClient) GetServiceInstance(getInput *GetServiceInstanceInput) (*ServiceInstance, error) {
+	var serviceInstance ServiceInstance
+	if err := c.getResource(getInput.Name, &serviceInstance); err != nil {
+		return nil, err
+	}
+
+	return &serviceInstance, nil
+}
+
+type DeleteServiceInstanceInput struct {
+	// Name of the Database Cloud Service instance.
+	// Required.
+	Name string `json:"serviceId"`
+}
+
+func (c *ServiceInstanceClient) DeleteServiceInstance(deleteInput *DeleteServiceInstanceInput) error {
+	if c.Timeout == 0 {
+		c.Timeout = WaitForServiceInstanceDeleteTimeout
+	}
+	// Call to delete the service instance
+	// If delete fails, rerun it in case the instance still has not been setup correctly.
+	// An instance takes additional time to setup after it's configured.
+	var deleteErr error
+	for i := 0; i < ServiceInstanceDeleteRetry; i++ {
+		if deleteErr = c.deleteResource(deleteInput.Name); deleteErr != nil {
+			time.Sleep(30 * time.Second)
+			continue
+		}
+		break
+	}
+	if deleteErr != nil {
+		return deleteErr
+	}
+
+	// Call wait for instance deleted now, as deleting the instance is an eventually consistent operation
+	getInput := &GetServiceInstanceInput{
+		Name: deleteInput.Name,
+	}
+
+	// Wait for instance to be deleted
+	return c.WaitForServiceInstanceDeleted(getInput, c.Timeout)
+}
+
+// WaitForServiceInstanceDeleted waits for a service instance to be fully deleted.
+func (c *ServiceInstanceClient) WaitForServiceInstanceDeleted(input *GetServiceInstanceInput, timeoutSeconds time.Duration) error {
+	return c.client.WaitFor("service instance to be deleted", timeoutSeconds, func() (bool, error) {
+		info, err := c.GetServiceInstance(input)
+		if err != nil {
+			if client.WasNotFoundError(err) {
+				// Service Instance could not be found, thus deleted
+				return true, nil
+			}
+			// Some other error occurred trying to get instance, exit
+			return false, err
+		}
+		switch s := info.Status; s {
+		case ServiceInstanceTerminating:
+			c.client.DebugLogString("Service Instance terminating")
+			return false, nil
+		default:
+			c.client.DebugLogString(fmt.Sprintf("Unknown instance state: %s, waiting", s))
+			return false, nil
+		}
+	})
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
@@ -460,6 +460,8 @@ func (c *ServiceInstanceClient) CreateServiceInstance(input *CreateServiceInstan
 			return serviceInstance, nil
 		}
 	}
+	time.Sleep(10 * time.Minute)
+
 	return nil, serviceInstanceError
 }
 
@@ -487,6 +489,7 @@ func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateS
 		}
 		return nil, serviceInstanceError
 	}
+
 	return serviceInstance, nil
 }
 

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
@@ -460,8 +460,6 @@ func (c *ServiceInstanceClient) CreateServiceInstance(input *CreateServiceInstan
 			return serviceInstance, nil
 		}
 	}
-	time.Sleep(10 * time.Minute)
-
 	return nil, serviceInstanceError
 }
 
@@ -489,7 +487,6 @@ func (c *ServiceInstanceClient) startServiceInstance(name string, input *CreateS
 		}
 		return nil, serviceInstanceError
 	}
-
 	return serviceInstance, nil
 }
 

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/test_utils.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/test_utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-oracle-terraform/opc"
 )
 
-func getDatabaseTestClient(c *opc.Config) (*DatabaseClient, error) {
+func GetDatabaseTestClient(c *opc.Config) (*DatabaseClient, error) {
 	// Build up config with default values if omitted
 
 	if c.IdentityDomain == nil {

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/test_utils.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/test_utils.go
@@ -1,0 +1,47 @@
+package database
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/hashicorp/go-oracle-terraform/opc"
+)
+
+func getDatabaseTestClient(c *opc.Config) (*DatabaseClient, error) {
+	// Build up config with default values if omitted
+
+	if c.IdentityDomain == nil {
+		domain := os.Getenv("OPC_IDENTITY_DOMAIN")
+		c.IdentityDomain = &domain
+	}
+
+	if c.Username == nil {
+		username := os.Getenv("OPC_USERNAME")
+		c.Username = &username
+	}
+
+	if c.Password == nil {
+		password := os.Getenv("OPC_PASSWORD")
+		c.Password = &password
+	}
+
+	if c.APIEndpoint == nil {
+		apiEndpoint, err := url.Parse(os.Getenv("OPC_DATABASE_ENDPOINT"))
+		if err != nil {
+			return nil, err
+		}
+		c.APIEndpoint = apiEndpoint
+	}
+
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				Proxy:               http.ProxyFromEnvironment,
+				TLSHandshakeTimeout: 120 * time.Second},
+		}
+	}
+
+	return NewDatabaseClient(c)
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/container.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/container.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const CONTAINER_VERSION = "v1"
-
 // Container describes an existing Container.
 type Container struct {
 	// The name of the Container
@@ -58,7 +56,7 @@ type CreateContainerInput struct {
 func (c *StorageClient) CreateContainer(input *CreateContainerInput) (*Container, error) {
 	headers := make(map[string]string)
 
-	input.Name = c.getQualifiedName(CONTAINER_VERSION, input.Name)
+	input.Name = c.getQualifiedName(input.Name)
 
 	// There are default values for these that we don't want to zero out if Read and Write ACLs are not set.
 	if len(input.ReadACLs) > 0 {
@@ -88,12 +86,12 @@ func (c *StorageClient) CreateContainer(input *CreateContainerInput) (*Container
 type DeleteContainerInput struct {
 	// The name of the Container
 	// Required
-	Name string `json:name`
+	Name string `json:"name"`
 }
 
 // DeleteContainer deletes the Container with the given name.
 func (c *StorageClient) DeleteContainer(input *DeleteContainerInput) error {
-	input.Name = c.getQualifiedName(CONTAINER_VERSION, input.Name)
+	input.Name = c.getQualifiedName(input.Name)
 	return c.deleteResource(input.Name)
 }
 
@@ -101,13 +99,13 @@ func (c *StorageClient) DeleteContainer(input *DeleteContainerInput) error {
 type GetContainerInput struct {
 	// The name of the Container
 	// Required
-	Name string `json:name`
+	Name string `json:"name"`
 }
 
 // GetContainer retrieves the Container with the given name.
 func (c *StorageClient) GetContainer(input *GetContainerInput) (*Container, error) {
 	var container Container
-	input.Name = c.getQualifiedName(CONTAINER_VERSION, input.Name)
+	input.Name = c.getQualifiedName(input.Name)
 
 	rsp, err := c.getResource(input.Name, &container)
 	if err != nil {
@@ -160,7 +158,7 @@ func (c *StorageClient) UpdateContainer(input *UpdateContainerInput) (*Container
 	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.AllowedOrigins, " ")
 	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(input.MaxAge)
 
-	input.Name = c.getQualifiedName(CONTAINER_VERSION, input.Name)
+	input.Name = c.getQualifiedName(input.Name)
 	if err := c.updateResource(input.Name, headers); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/object.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/object.go
@@ -1,0 +1,270 @@
+//- Object Resource + Data Source
+//-
+//- Satisfies Create, Read, Delete.
+//- Object Metadata should be handled in a separate resource
+//- Can only replace objects, so no Update method, use ForceNew in Terraform
+
+package storage
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+type ObjectClient struct {
+	StorageClient
+}
+
+func (c *StorageClient) Objects() *ObjectClient {
+	return &ObjectClient{
+		StorageClient: StorageClient{
+			client:      c.client,
+			authToken:   c.authToken,
+			tokenIssued: c.tokenIssued,
+		},
+	}
+}
+
+// Header Constants
+const (
+	h_AcceptRanges       = "Accept-Ranges"
+	h_ContentDisposition = "Content-Disposition"
+	h_ContentEncoding    = "Content-Encoding"
+	h_ContentLength      = "Content-Length"
+	h_ContentType        = "Content-Type"
+	h_CopyFrom           = "X-Copy-From"
+	h_Date               = "Date"
+	h_DeleteAt           = "X-Delete-At"
+	h_ETag               = "ETag"
+	h_LastModified       = "Last-Modified"
+	h_Newest             = "X-Newest"
+	h_ObjectManifest     = "X-Object-Manifest"
+	h_Range              = "Range"
+	h_Timestamp          = "X-Timestamp"
+	h_TransactionID      = "X-Trans-Id"
+	h_TransferEncoding   = "Transfer-Encoding"
+)
+
+// Object Info describes an existing object
+// Optional values may not be passed in as response headers
+// TODO: Add query parameters if needed
+type ObjectInfo struct {
+	// Name of the object
+	Name string
+	// Type of ranges the object accepts
+	AcceptRanges string
+	// Name of the container
+	Container string
+	// Optional: Specifies the override behavior for the browser
+	ContentDisposition string
+	// Optional: Content's Encoding header
+	ContentEncoding string
+	// Length of the object in bytes
+	ContentLength int
+	// Type of the content
+	ContentType string
+	// Date of the transaction in ISO 8601 format.
+	// Null value means the token never expires
+	Date string
+	// For objects smaller than 5GB, MD5 checksum of the object content.
+	// Otherwise MD5 sum of the concatenated string of MD5 sums and ETAGS
+	// for each segment of the manifest. Enclosed in double-quote characters
+	Etag string
+	// Date and time when the object was created/modified. ISO 8601.
+	LastModified string
+	// Optional: Date+Time in EPOCH that the object will be deleted.
+	DeleteAt int
+	// Optional: The dynamic large object manifest object.
+	ObjectManifest string
+
+	// TODO: X-Object-Meta-{name}
+
+	// Date and time in UNIX EPOCH when the account, container, _or_ object
+	// was initially created as a current version.
+	Timestamp string
+	// Transaction ID of the request - Used for bug reports to service providers
+	TransactionID string
+}
+
+// Input struct for a Create Method to create a storage object
+// TODO: Add query parameters if needed
+type CreateObjectInput struct {
+	// Name of the object.
+	// Required
+	Name string
+	// Body of the request to use. Accepts an io.ReadSeeker, so options are open to
+	// the downstream consumer
+	// Required
+	Body io.ReadSeeker
+	// Name of the container to place the object
+	// Required
+	Container string
+	// Override the behavior of the browser.
+	// Optional
+	ContentDisposition string
+	// Set the content-encoding metadata
+	// Optional
+	ContentEncoding string
+	// Changes the MIME type for the object
+	// Optional - Defaults to 'text/plain'
+	ContentType string
+	// Specify the `container/object` to copy from. Must be UTF-8 encoded
+	// and the name of the container and object must be URL-encoded
+	// Optional
+	CopyFrom string
+	// Specify the number of seconds after which the system deletes the object.
+	// Optional
+	DeleteAt int
+
+	// MD5 checksum value of the request body. Unquoted
+	// Strongly recommended, not required.
+	ETag string
+	// TODO: If-None-Match.
+
+	// Sets the transfer encoding. Can only be "chunked" or nil.
+	// Requires content-length to be 0 if set.
+	// Optional
+	TransferEncoding string
+	// TODO: X-Object-Meta-{name}
+}
+
+// CreateObject creates a new Object inside of a container.
+func (c *ObjectClient) CreateObject(input *CreateObjectInput) (*ObjectInfo, error) {
+	headers := make(map[string]string)
+
+	name := c.getQualifiedName(fmt.Sprintf("%s/%s", input.Container, input.Name))
+
+	if input.ContentDisposition != "" {
+		headers[h_ContentDisposition] = input.ContentDisposition
+	}
+	if input.ContentEncoding != "" {
+		headers[h_ContentEncoding] = input.ContentEncoding
+	}
+	if input.ContentType != "" {
+		headers[h_ContentType] = input.ContentType
+	}
+	if input.ETag != "" {
+		headers[h_ETag] = input.ETag
+	}
+	if input.TransferEncoding != "" {
+		headers[h_TransferEncoding] = input.TransferEncoding
+	}
+	if input.CopyFrom != "" {
+		headers[h_CopyFrom] = input.CopyFrom
+	}
+	if input.DeleteAt != 0 {
+		headers[h_DeleteAt] = fmt.Sprintf("%d", input.DeleteAt)
+	}
+
+	if input.Body == nil {
+		return nil, fmt.Errorf("Body cannot be nil")
+	}
+
+	if err := c.createResourceBody(name, headers, input.Body); err != nil {
+		return nil, err
+	}
+
+	getInput := &GetObjectInput{
+		Name:      input.Name,
+		Container: input.Container,
+	}
+
+	return c.GetObject(getInput)
+}
+
+// Get details on a storage object
+// TODO: Add query parameters if needed
+type GetObjectInput struct {
+	// TODO If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+	// If we actually want to support these
+
+	// Name of the object to get details on
+	// Required
+	Name string
+	// Name of the container
+	// Required
+	Container string
+	// Range of data to receive. Must be specified via a byte range:
+	// bytes=-5; bytes=10-15. Accept the entire string here, as multiple ranges
+	// can be specified with a comma delimiter
+	// Optional
+	Range string
+	// If set to true, Object Storage queries all replicas to return the most recent one.
+	// If you omit this header, Object Storage responds faster after it finds one valid replica.
+	// Because setting this header to true is more expensive for the back end, use it only when
+	// it is absolutely needed.
+	// Optional
+	Newest bool
+}
+
+// Accepts a input struct, returns an info struct
+func (c *ObjectClient) GetObject(input *GetObjectInput) (*ObjectInfo, error) {
+	var object ObjectInfo
+	headers := make(map[string]string)
+
+	name := c.getQualifiedName(fmt.Sprintf("%s/%s", input.Container, input.Name))
+
+	// Build request headers
+	headers[h_Range] = input.Range
+	headers[h_Newest] = fmt.Sprintf("%t", input.Newest)
+
+	resp, err := c.getResourceHeaders(name, &object, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set Name and container, not returned from API
+	object.Name = input.Name
+	object.Container = input.Container
+
+	return c.success(resp, &object)
+}
+
+// Input struct for deleting objects
+// TODO: Add query parameters if needed
+type DeleteObjectInput struct {
+	// Name of the Object to delete
+	// Required
+	Name string
+	// Name of the container
+	// Required
+	Container string
+}
+
+func (c *ObjectClient) DeleteObject(input *DeleteObjectInput) error {
+	name := fmt.Sprintf("%s/%s", input.Container, input.Name)
+	return c.deleteResource(c.getQualifiedName(name))
+}
+
+func (c *ObjectClient) success(resp *http.Response, object *ObjectInfo) (*ObjectInfo, error) {
+	var err error
+	// Translate response headers into object info struct
+	object.AcceptRanges = resp.Header.Get(h_AcceptRanges)
+	object.ContentDisposition = resp.Header.Get(h_ContentDisposition)
+	object.ContentEncoding = resp.Header.Get(h_ContentEncoding)
+	object.ContentType = resp.Header.Get(h_ContentType)
+	object.Date = resp.Header.Get(h_Date)
+	object.Etag = resp.Header.Get(h_ETag)
+	object.LastModified = resp.Header.Get(h_LastModified)
+	object.ObjectManifest = resp.Header.Get(h_ObjectManifest)
+	object.Timestamp = resp.Header.Get(h_Timestamp)
+	object.TransactionID = resp.Header.Get(h_TransactionID)
+
+	if v := resp.Header.Get(h_ContentLength); v != "" {
+		object.ContentLength, err = strconv.Atoi(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if v := resp.Header.Get(h_DeleteAt); v != "" {
+		object.DeleteAt, err = strconv.Atoi(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return object, nil
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_client.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ const STR_ACCOUNT = "/Storage-%s"
 const STR_USERNAME = "/Storage-%s:%s"
 const AUTH_HEADER = "X-Auth-Token"
 const STR_QUALIFIED_NAME = "%s%s/%s"
+const API_VERSION = "v1"
 
 // Client represents an authenticated compute client, with compute credentials and an api client.
 type StorageClient struct {
@@ -23,30 +25,48 @@ type StorageClient struct {
 }
 
 func NewStorageClient(c *opc.Config) (*StorageClient, error) {
-	storageClient := &StorageClient{}
-	client, err := client.NewClient(c)
+	sClient := &StorageClient{}
+	opcClient, err := client.NewClient(c)
 	if err != nil {
 		return nil, err
 	}
-	storageClient.client = client
+	sClient.client = opcClient
 
-	if err := storageClient.getAuthenticationToken(); err != nil {
+	if err := sClient.getAuthenticationToken(); err != nil {
 		return nil, err
 	}
 
-	return storageClient, nil
+	return sClient, nil
 }
 
+// Execute a request with a nil body
 func (c *StorageClient) executeRequest(method, path string, headers interface{}) (*http.Response, error) {
-	req, err := c.client.BuildRequest(method, path, nil)
+	return c.executeRequestBody(method, path, headers, nil)
+}
+
+// Execute a request with a body supplied. The body can be nil for the request.
+// Does not marshal the body into json to create the request
+func (c *StorageClient) executeRequestBody(method, path string, headers interface{}, body io.ReadSeeker) (*http.Response, error) {
+	req, err := c.client.BuildNonJSONRequest(method, path, body)
 	if err != nil {
 		return nil, err
 	}
+
+	debugReqString := fmt.Sprintf("%s (%s) %s", req.Method, req.URL, req.Proto)
+	var debugHeaders []string
 
 	if headers != nil {
 		for k, v := range headers.(map[string]string) {
+			debugHeaders = append(debugHeaders,
+				fmt.Sprintf("%v: %v\n", strings.ToLower(k), v))
+
 			req.Header.Add(k, v)
 		}
+		debugReqString = fmt.Sprintf("%s\n%s", debugReqString, debugHeaders)
+	}
+
+	if !strings.Contains(path, "/auth/") {
+		c.client.DebugLogString(debugReqString)
 	}
 
 	// If we have an authentication token, let's authenticate, refreshing cookie if need be
@@ -75,14 +95,14 @@ func (c *StorageClient) getAccount() string {
 }
 
 // GetQualifiedName returns the fully-qualified name of a storage object, e.g. /v1/{account}/{name}
-func (c *StorageClient) getQualifiedName(version string, name string) string {
+func (c *StorageClient) getQualifiedName(name string) string {
 	if name == "" {
 		return ""
 	}
-	if strings.HasPrefix(name, "/Storage-") || strings.HasPrefix(name, "v1/") {
+	if strings.HasPrefix(name, "/Storage-") || strings.HasPrefix(name, API_VERSION+"/") {
 		return name
 	}
-	return fmt.Sprintf(STR_QUALIFIED_NAME, version, c.getAccount(), name)
+	return fmt.Sprintf(STR_QUALIFIED_NAME, API_VERSION, c.getAccount(), name)
 }
 
 // GetUnqualifiedName returns the unqualified name of a Storage object, e.g. the {name} part of /v1/{account}/{name}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_resource_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/storage_resource_client.go
@@ -1,11 +1,16 @@
 package storage
 
 import (
+	"io"
 	"net/http"
 )
 
 func (c *StorageClient) createResource(name string, requestHeaders interface{}) error {
-	_, err := c.executeRequest("PUT", name, requestHeaders)
+	return c.createResourceBody(name, requestHeaders, nil)
+}
+
+func (c *StorageClient) createResourceBody(name string, requestHeaders interface{}, body io.ReadSeeker) error {
+	_, err := c.executeRequestBody("PUT", name, requestHeaders, body)
 	if err != nil {
 		return err
 	}
@@ -23,7 +28,15 @@ func (c *StorageClient) updateResource(name string, requestHeaders interface{}) 
 }
 
 func (c *StorageClient) getResource(name string, responseBody interface{}) (*http.Response, error) {
-	rsp, err := c.executeRequest("GET", name, nil)
+	return c.getResourceHeaders(name, responseBody, nil)
+}
+
+func (c *StorageClient) getResourceHeaders(
+	name string,
+	responseBody interface{},
+	requestHeaders interface{},
+) (*http.Response, error) {
+	rsp, err := c.executeRequest("GET", name, requestHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -252,7 +252,7 @@
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
 			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
 			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "v0.1.9",
+			"version": "=v0.1.9",
 			"versionExact": "v0.1.9"
 		},
 		{
@@ -260,7 +260,7 @@
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
 			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
 			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "v0.1.9",
+			"version": "=v0.1.9",
 			"versionExact": "v0.1.9"
 		},
 		{
@@ -268,7 +268,7 @@
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
 			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
 			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "v0.1.9",
+			"version": "=v0.1.9",
 			"versionExact": "v0.1.9"
 		},
 		{
@@ -276,7 +276,7 @@
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
 			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
 			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "v0.1.9",
+			"version": "=v0.1.9",
 			"versionExact": "v0.1.9"
 		},
 		{
@@ -284,7 +284,7 @@
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
 			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
 			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "v0.1.9",
+			"version": "=v0.1.9",
 			"versionExact": "v0.1.9"
 		},
 		{

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,42 +250,42 @@
 		{
 			"checksumSHA1": "zna4OotvTDjb26NKZ1Y4kwDPZGM=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
-			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "=v0.1.9",
-			"versionExact": "v0.1.9"
+			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
+			"revisionTime": "2017-07-27T17:19:28Z",
+			"version": "=v0.2.0",
+			"versionExact": "v0.2.0"
 		},
 		{
 			"checksumSHA1": "KX87DJWFbBPcFhxiMLk7j/O9VLE=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
-			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "=v0.1.9",
-			"versionExact": "v0.1.9"
+			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
+			"revisionTime": "2017-07-27T17:19:28Z",
+			"version": "=v0.2.0",
+			"versionExact": "v0.2.0"
 		},
 		{
-			"checksumSHA1": "Q+8VPuadraoxDLPDcdKDTTShbHE=",
+			"checksumSHA1": "RJPtoZ0wbakSm3OwqiFuDmom7os=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
-			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "=v0.1.9",
-			"versionExact": "v0.1.9"
+			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
+			"revisionTime": "2017-07-27T17:19:28Z",
+			"version": "=v0.2.0",
+			"versionExact": "v0.2.0"
 		},
 		{
 			"checksumSHA1": "JbuYtbJkx3r1BLuCMymkri0Q1BI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
-			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "=v0.1.9",
-			"versionExact": "v0.1.9"
+			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
+			"revisionTime": "2017-07-27T17:19:28Z",
+			"version": "=v0.2.0",
+			"versionExact": "v0.2.0"
 		},
 		{
 			"checksumSHA1": "RZ0JXaeUyiGFdvoHV0jUgOSZjVY=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
-			"revisionTime": "2017-07-20T21:51:35Z",
-			"version": "=v0.1.9",
-			"versionExact": "v0.1.9"
+			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
+			"revisionTime": "2017-07-27T17:19:28Z",
+			"version": "=v0.2.0",
+			"versionExact": "v0.2.0"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,34 +250,42 @@
 		{
 			"checksumSHA1": "zna4OotvTDjb26NKZ1Y4kwDPZGM=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "179f35b8fe403a090168d1d8f67b1c1f192914dc",
-			"revisionTime": "2017-07-19T14:17:38Z",
-			"version": "v0.1.7",
-			"versionExact": "v0.1.7"
+			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
+			"revisionTime": "2017-07-20T21:51:35Z",
+			"version": "v0.1.9",
+			"versionExact": "v0.1.9"
 		},
 		{
-			"checksumSHA1": "N7ghAYSHczBQIG/J8XIDd7uWHEk=",
+			"checksumSHA1": "KX87DJWFbBPcFhxiMLk7j/O9VLE=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "179f35b8fe403a090168d1d8f67b1c1f192914dc",
-			"revisionTime": "2017-07-19T14:17:38Z",
-			"version": "v0.1.7",
-			"versionExact": "v0.1.7"
+			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
+			"revisionTime": "2017-07-20T21:51:35Z",
+			"version": "v0.1.9",
+			"versionExact": "v0.1.9"
+		},
+		{
+			"checksumSHA1": "Q+8VPuadraoxDLPDcdKDTTShbHE=",
+			"path": "github.com/hashicorp/go-oracle-terraform/database",
+			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
+			"revisionTime": "2017-07-20T21:51:35Z",
+			"version": "v0.1.9",
+			"versionExact": "v0.1.9"
 		},
 		{
 			"checksumSHA1": "JbuYtbJkx3r1BLuCMymkri0Q1BI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "179f35b8fe403a090168d1d8f67b1c1f192914dc",
-			"revisionTime": "2017-07-19T14:17:38Z",
-			"version": "v0.1.7",
-			"versionExact": "v0.1.7"
+			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
+			"revisionTime": "2017-07-20T21:51:35Z",
+			"version": "v0.1.9",
+			"versionExact": "v0.1.9"
 		},
 		{
 			"checksumSHA1": "RZ0JXaeUyiGFdvoHV0jUgOSZjVY=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "179f35b8fe403a090168d1d8f67b1c1f192914dc",
-			"revisionTime": "2017-07-19T14:17:38Z",
-			"version": "v0.1.7",
-			"versionExact": "v0.1.7"
+			"revision": "21e2696ebec1849c0622c5c366a732d12e5c2d21",
+			"revisionTime": "2017-07-20T21:51:35Z",
+			"version": "v0.1.9",
+			"versionExact": "v0.1.9"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -248,44 +248,44 @@
 			"revision": "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
 		},
 		{
-			"checksumSHA1": "zna4OotvTDjb26NKZ1Y4kwDPZGM=",
+			"checksumSHA1": "8N/9z3bEh+6LqR9Yfe1+FcjJZDs=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
-			"revisionTime": "2017-07-27T17:19:28Z",
-			"version": "=v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
+			"revisionTime": "2017-08-07T20:01:57Z",
+			"version": "=v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
 			"checksumSHA1": "KX87DJWFbBPcFhxiMLk7j/O9VLE=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
-			"revisionTime": "2017-07-27T17:19:28Z",
-			"version": "=v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
+			"revisionTime": "2017-08-07T20:01:57Z",
+			"version": "=v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
-			"checksumSHA1": "RJPtoZ0wbakSm3OwqiFuDmom7os=",
+			"checksumSHA1": "PhmW3m7d3kwkT2WjndZiFr1UtNU=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
-			"revisionTime": "2017-07-27T17:19:28Z",
-			"version": "=v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
+			"revisionTime": "2017-08-07T20:01:57Z",
+			"version": "=v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
 			"checksumSHA1": "JbuYtbJkx3r1BLuCMymkri0Q1BI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
-			"revisionTime": "2017-07-27T17:19:28Z",
-			"version": "=v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
+			"revisionTime": "2017-08-07T20:01:57Z",
+			"version": "=v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
-			"checksumSHA1": "RZ0JXaeUyiGFdvoHV0jUgOSZjVY=",
+			"checksumSHA1": "rzRyfneT06rrYGYIvHEYwICsztU=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "dd9678ac5cc50d8577abe800c9e279f80bc53bef",
-			"revisionTime": "2017-07-27T17:19:28Z",
-			"version": "=v0.2.0",
-			"versionExact": "v0.2.0"
+			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
+			"revisionTime": "2017-08-07T20:01:57Z",
+			"version": "=v0.3.1",
+			"versionExact": "v0.3.1"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `storage_endpoint` - (Optional) The API endpoint to use, associated with your Oracle Storage Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_STORAGE_ENDPOINT` environment variable.
 
-* `database_endpont` - (Optional) The API endpoint to use, associated with Oracle Database Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_DATABASE_ENDPOINT` environment variable.
+* `database_endpoint` - (Optional) The API endpoint to use, associated with Oracle Database Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_DATABASE_ENDPOINT` environment variable.
 
 * `max_retries` - (Optional) The maximum number of tries to make for a successful response when operating on resources within Oracle Public Cloud. It can also be sourced from the `OPC_MAX_RETRIES` environment variable. Defaults to 1.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -45,7 +45,9 @@ The following arguments are supported:
 
 * `endpoint` - (Optional) The API endpoint to use, associated with your Oracle Public Cloud account. This is known as the `REST Endpoint` within the Oracle portal. It can also be sourced from the `OPC_ENDPOINT` environment variable.
 
-* `storage_endpoint` - (Optional) The API endpoint to use, associated with your Oracle Public Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_STORAGE_ENDPOINT` environment variable.
+* `storage_endpoint` - (Optional) The API endpoint to use, associated with your Oracle Storage Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_STORAGE_ENDPOINT` environment variable.
+
+* `database_endpont` - (Optional) The API endpoint to use, associated with Oracle Database Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_DATABASE_ENDPOINT` environment variable.
 
 * `max_retries` - (Optional) The maximum number of tries to make for a successful response when operating on resources within Oracle Public Cloud. It can also be sourced from the `OPC_MAX_RETRIES` environment variable. Defaults to 1.
 

--- a/website/docs/r/opc_compute_route.html.markdown
+++ b/website/docs/r/opc_compute_route.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # opc\_compute\_route
 
-The ``opc_compute_route`` resource creates and manages a route for an IP Network.
+The `opc_compute_route` resource creates and manages a route for an IP Network.
 
 ## Example Usage
 

--- a/website/docs/r/opc_database_service_instance.html.markdown
+++ b/website/docs/r/opc_database_service_instance.html.markdown
@@ -4,6 +4,7 @@ page_title: "Oracle: opc_database_service_instance"
 sidebar_current: "docs-opc-resource-service-instance"
 description: |-
   Creates and manages a service instance in an OPC identity domain.
+
 ---
 
 # opc\_database\_service\_instance
@@ -21,7 +22,7 @@ resource "opc_database_service_instance" "default" {
   shape = "oc1m"
   subscription_type = "HOURLY"
   version = "12.2.0.1"
-  vm_public_key = "an ssh public key"
+  vm_public_key = "A ssh public key"
   parameter {
     admin_password = "Test_String7"
     backup_destination = "NONE"
@@ -37,15 +38,15 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Service Instance.
 
-* `edition` - (Required) Database edition for the service instance. Possible values are SE, EE, EE_HP, or EE_EP.
+* `edition` - (Required) Database edition for the service instance. Possible values are `SE`, `EE`, `EE_HP`, or `EE_EP`.
 
-* `level` - (Required) Service level for the service instance. Possible values are BASIC or PAAS.
+* `level` - (Required) Service level for the service instance. Possible values are `BASIC` or `PAAS`.
 
-* `shape` - (Required) Desired compute shape. Possible values are oc3, oc4, oc5, oc6, oc1m, oc2m, oc3m, or oc4m.
+* `shape` - (Required) Desired compute shape. Possible values are `oc3`, `oc4`, `oc5`, `oc6`, `oc1m`, `oc2m`, `oc3m`, or `oc4m`.
 
-* `subscription_type` - (Required) Billing unit. Possible values are HOURLY or MONTHLY.
+* `subscription_type` - (Required) Billing unit. Possible values are `HOURLY` or `MONTHLY`.
 
-* `version` - (Required) Oracle Database software version; one of: 12.2.0.1, 12.1.0.2, or 11.2.0.4.
+* `version` - (Required) Oracle Database software version; one of: `12.2.0.1`, `12.1.0.2`, or `11.2.0.4`.
 
 * `vm_public_key` - (Required) Public key for the secure shell (SSH). This key will be used for authentication when connecting to the Database Cloud Service instance using an SSH client.
 
@@ -57,57 +58,57 @@ Parameter supports the following:
 
 * `admin_password` - (Required) Password for Oracle Database administrator users sys and system. The password must meet the following requirements: Starts with a letter. Is between 8 and 30 characters long. Contains letters, at least one number, and optionally, any number of these special characters: dollar sign ($), pound sign (#), and underscore ( _ )
 
-* `backup_destination` - (Required) Backup Destination. Possible values are BOTH, OSS, NONE.
+* `backup_destination` - (Required) Backup Destination. Possible values are `BOTH`, `OSS`, `NONE`.
 
-* `char_set` - (Required) Character Set for the Database Cloud Service Instance. Default value is AL32UTF8.
+* `char_set` - (Required) Character Set for the Database Cloud Service Instance. All possible values are listed under the [parameters section documentation](http://docs.oracle.com/en/cloud/paas/database-dbaas-cloud/csdbr/op-paas-service-dbcs-api-v1.1-instances-%7BidentityDomainId%7D-post.html). Default value is `AL32UTF8`.
 
-`usable_storage` - (Required) Storage size for data (in GB). Minimum value is 15. Maximum value depends on the backup destination: if BOTH is specified, the maximum value is 1200; if OSS or NONE is specified, the maximum value is 2048.
+`usable_storage` - (Required) Storage size for data (in GB). Minimum value is `15`. Maximum value depends on the backup destination: if `BOTH` is specified, the maximum value is `1200`; if `OSS` or `NONE` is specified, the maximum value is `2048`.
 
-* `cloud_storage_container` - (Optional) Name of the Oracle Storage Cloud Service container used to provide storage for your service instance backups. Use the following format to specify the container name: <storageservicename>-<storageidentitydomain>/<containername>
+* `cloud_storage_container` - (Optional) Name of the Oracle Storage Cloud Service container used to provide storage for your service instance backups. Use the following format to specify the container name: `<storageservicename>-<storageidentitydomain>/<containername>`
 
 * `cloud_storage_username` - (Optional) Username for the Oracle Storage Cloud Service administrator.
 
 * `cloud_storage_password` - (Optional) Password for the Oracle Storage Cloud Service administrator.
 
-* `create_storage_container_if_missing` - (Optional) Specify if the given cloud_storage_container is to be created if it does not already exist. Valid values are true and false. Default value is false.
+* `create_storage_container_if_missing` - (Optional) Specify if the given cloud_storage_container is to be created if it does not already exist. Default value is `false`.
 
-* `disaster_recovery` - (Optional) Specify if an Oracle Data Guard configuration is created using the Disaster Recovery option or the High Availability option. Valid values are yes and no. Default value is no.
+* `disaster_recovery` - (Optional) Specify if an Oracle Data Guard configuration is created using the Disaster Recovery option or the High Availability option. Valid values are `yes` and `no`. Default value is no.
 
-* `failover_database` - Specify if an Oracle Data Guard configuration comprising a primary database and a standby database is created. Valid values are yes and no. Default value is no.
+* `failover_database` - Specify if an Oracle Data Guard configuration comprising a primary database and a standby database is created. Valid values are `yes` and `no`. Default value is `no`.
 
-* `golden_gate` - (Optional) Specify if the database should be configured for use as the replication database of an Oracle GoldenGate Cloud Service instance. Valid values are yes and no. Default value is no. You cannot set goldenGate to yes if either isRac or failoverDatabase is set to yes.
+* `golden_gate` - (Optional) Specify if the database should be configured for use as the replication database of an Oracle GoldenGate Cloud Service instance. Valid values are `yes` and `no`. Default value is `no`. You cannot set `goldenGate` to `yes` if either `is_rac` or `failoverDatabase` is set to `yes`.
 
-* `ibkup` - (Optional) Specify if the service instance's database should, after the instance is created, be replaced by a database stored in an existing cloud backup that was created using Oracle Database Backup Cloud Service. Valid values are yes and no. Default value is no.
+* `ibkup` - (Optional) Specify if the service instance's database should, after the instance is created, be replaced by a database stored in an existing cloud backup that was created using Oracle Database Backup Cloud Service. Valid values are `yes` and `no`. Default value is `no`.
 
 * `ibkup_cloud_storage_username` - (Optional)
-Username of the Oracle Cloud user. This parameter is required if ibkup is set to yes.
+Username of the Oracle Cloud user. This parameter is required if `ibkup` is set to `yes`.
 
 * `ibkup_cloud_storage_password` - (Optional)
-Password of the Oracle Cloud user specified in ibkup_cloud_storage_user. This parameter is required if ibkup is set to yes.
+Password of the Oracle Cloud user specified in `ibkup_cloud_storage_user`. This parameter is required if `ibkup` is set to yes.
 
-* `ibkup_database_id` - (Optional) Database id of the database from which the existing cloud backup was created. This parameter is required if ibkup is set to yes.
+* `ibkup_database_id` - (Optional) Database id of the database from which the existing cloud backup was created. This parameter is required if `ibkup` is set to `yes`.
 
-* `ibkup_decryption_key` - (Optional) Password used to create the existing, password-encrypted cloud backup. This password is used to decrypt the backup. Specify either ibkup_decryption_key or ibkup_wallet_file_content for decrypting the backup. This parameter is required if ibkup is set to yes.
+* `ibkup_decryption_key` - (Optional) Password used to create the existing, password-encrypted cloud backup. This password is used to decrypt the backup. Specify either `ibkup_decryption_key` or `ibkup_wallet_file_content` for decrypting the backup. This parameter is required if `ibkup` is set to `yes`.
 
-* `ibkup_wallet_file_content` - (Optional) String containing the xsd:base64Binary representation of the cloud backup's wallet file. This wallet is used to decrypt the backup. Specify either ibkup_decryption_key or ibkup_wallet_file_content for decrypting the backup. This parameter is required if ibkup is set to yes.
+* `ibkup_wallet_file_content` - (Optional) String containing the xsd:base64Binary representation of the cloud backup's wallet file. This wallet is used to decrypt the backup. Specify either `ibkup_decryption_key` or `ibkup_wallet_file_content` for decrypting the backup. This parameter is required if `ibkup` is set to yes.
 
-* `is_rac` - (Optional) Specify if a cluster database using Oracle Real Application Clusters should be configured. Valid values are yes and no. Default value is no.
+* `is_rac` - (Optional) Specify if a cluster database using Oracle Real Application Clusters should be configured. Valid values are `yes` and `no`. Default value is `no`.
 
-* `n_char_set` - (Optional) National Character Set for the Database Cloud Service instance. Valid values are AL16UTF16 and UTF8. Default value is AL16UTF16.
+* `n_char_set` - (Optional) National Character Set for the Database Cloud Service instance. Valid values are `AL16UTF16` and `UTF8`. Default value is `AL16UTF16`.
 
-* `pdb_name` - (Optional) This attribute is valid when Database Cloud Service instance is configured with version 12c. Pluggable Database Name for the Database Cloud Service instance. Default value is pdb1.
+* `pdb_name` - (Optional) This attribute is valid when Database Cloud Service instance is configured with version 12c. Pluggable Database Name for the Database Cloud Service instance. Default value is `pdb1`.
 
-* `sid` - (Optional) Database Name for the Database Cloud Service instance. Default value is ORCL.
+* `sid` - (Optional) Database Name for the Database Cloud Service instance. Default value is `ORCL`.
 
 * `source_service_name` - (Optional) Indicates that the service instance should be created as a "snapshot clone" of another service instance. Provide the name of the existing service instance whose snapshot is to be used.
 
 * `snapshot_name` - (Optional) The name of the snapshot of the service instance specified by sourceServiceName that is to be used to create a "snapshot clone". This parameter is valid only if source_service_name is specified.
 
-* `timezone` - (Optional) Time Zone for the Database Cloud Service instance. Default value is UTC.
+* `timezone` - (Optional) Time Zone for the Database Cloud Service instance. Default value is `UTC`.
 
-* `type` - (Optional) Component type to which the set of parameters applies. Defaults to db
+* `type` - (Optional) Component type to which the set of parameters applies. Defaults to `db`
 
-* `db_demo` - (Optional) Indicates whether to include the Demos PDB. Valid values are yes or no.
+* `db_demo` - (Optional) Indicates whether to include the Demos PDB. Valid values are `yes` or `no`.
 
 In addition to the above, the following values are exported:
 

--- a/website/docs/r/opc_database_service_instance.html.markdown
+++ b/website/docs/r/opc_database_service_instance.html.markdown
@@ -1,0 +1,168 @@
+---
+layout: "opc"
+page_title: "Oracle: opc_database_service_instance"
+sidebar_current: "docs-opc-resource-service-instance"
+description: |-
+  Creates and manages a service instance in an OPC identity domain.
+---
+
+# opc\_database\_service\_instance
+
+The ``opc_database_service_instance`` resource creates and manages a service instance in an OPC identity domain.
+
+## Example Usage
+
+```hcl
+resource "opc_database_service_instance" "default" {
+  name        = "service-instance-1"
+  description = "This is a description for an service instance"
+  edition = "EE_EP"
+  level = "PAAS"
+  shape = "oc1m"
+  subscription_type = "HOURLY"
+  version = "12.2.0.1"
+  vm_public_key = "an ssh public key"
+  parameter {
+    admin_password = "Test_String7"
+    backup_destination = "NONE"
+    sid = "ORCL"
+    usable_storage = 15
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Service Instance.
+
+* `edition` - (Required) Database edition for the service instance. Possible values are SE, EE, EE_HP, or EE_EP.
+
+* `level` - (Required) Service level for the service instance. Possible values are BASIC or PAAS.
+
+* `shape` - (Required) Desired compute shape. Possible values are oc3, oc4, oc5, oc6, oc1m, oc2m, oc3m, or oc4m.
+
+* `subscription_type` - (Required) Billing unit. Possible values are HOURLY or MONTHLY.
+
+* `version` - (Required) Oracle Database software version; one of: 12.2.0.1, 12.1.0.2, or 11.2.0.4.
+
+* `vm_public_key` - (Required) Public key for the secure shell (SSH). This key will be used for authentication when connecting to the Database Cloud Service instance using an SSH client.
+
+* `parameter` - (Optional) Additional configuration for a service instance. This set is required if level is PAAS. Parameter is documented below.
+
+* `description` - (Optional) A description of the Service Instance.
+
+Parameter supports the following:
+
+* `admin_password` - (Required) Password for Oracle Database administrator users sys and system. The password must meet the following requirements: Starts with a letter. Is between 8 and 30 characters long. Contains letters, at least one number, and optionally, any number of these special characters: dollar sign ($), pound sign (#), and underscore ( _ )
+
+* `backup_destination` - (Required) Backup Destination. Possible values are BOTH, OSS, NONE.
+
+* `char_set` - (Required) Character Set for the Database Cloud Service Instance. Default value is AL32UTF8.
+
+`usable_storage` - (Required) Storage size for data (in GB). Minimum value is 15. Maximum value depends on the backup destination: if BOTH is specified, the maximum value is 1200; if OSS or NONE is specified, the maximum value is 2048.
+
+* `cloud_storage_container` - (Optional) Name of the Oracle Storage Cloud Service container used to provide storage for your service instance backups. Use the following format to specify the container name: <storageservicename>-<storageidentitydomain>/<containername>
+
+* `cloud_storage_username` - (Optional) Username for the Oracle Storage Cloud Service administrator.
+
+* `cloud_storage_password` - (Optional) Password for the Oracle Storage Cloud Service administrator.
+
+* `create_storage_container_if_missing` - (Optional) Specify if the given cloud_storage_container is to be created if it does not already exist. Valid values are true and false. Default value is false.
+
+* `disaster_recovery` - (Optional) Specify if an Oracle Data Guard configuration is created using the Disaster Recovery option or the High Availability option. Valid values are yes and no. Default value is no.
+
+* `failover_database` - Specify if an Oracle Data Guard configuration comprising a primary database and a standby database is created. Valid values are yes and no. Default value is no.
+
+* `golden_gate` - (Optional) Specify if the database should be configured for use as the replication database of an Oracle GoldenGate Cloud Service instance. Valid values are yes and no. Default value is no. You cannot set goldenGate to yes if either isRac or failoverDatabase is set to yes.
+
+* `ibkup` - (Optional) Specify if the service instance's database should, after the instance is created, be replaced by a database stored in an existing cloud backup that was created using Oracle Database Backup Cloud Service. Valid values are yes and no. Default value is no.
+
+* `ibkup_cloud_storage_username` - (Optional)
+Username of the Oracle Cloud user. This parameter is required if ibkup is set to yes.
+
+* `ibkup_cloud_storage_password` - (Optional)
+Password of the Oracle Cloud user specified in ibkup_cloud_storage_user. This parameter is required if ibkup is set to yes.
+
+* `ibkup_database_id` - (Optional) Database id of the database from which the existing cloud backup was created. This parameter is required if ibkup is set to yes.
+
+* `ibkup_decryption_key` - (Optional) Password used to create the existing, password-encrypted cloud backup. This password is used to decrypt the backup. Specify either ibkup_decryption_key or ibkup_wallet_file_content for decrypting the backup. This parameter is required if ibkup is set to yes.
+
+* `ibkup_wallet_file_content` - (Optional) String containing the xsd:base64Binary representation of the cloud backup's wallet file. This wallet is used to decrypt the backup. Specify either ibkup_decryption_key or ibkup_wallet_file_content for decrypting the backup. This parameter is required if ibkup is set to yes.
+
+* `is_rac` - (Optional) Specify if a cluster database using Oracle Real Application Clusters should be configured. Valid values are yes and no. Default value is no.
+
+* `n_char_set` - (Optional) National Character Set for the Database Cloud Service instance. Valid values are AL16UTF16 and UTF8. Default value is AL16UTF16.
+
+* `pdb_name` - (Optional) This attribute is valid when Database Cloud Service instance is configured with version 12c. Pluggable Database Name for the Database Cloud Service instance. Default value is pdb1.
+
+* `sid` - (Optional) Database Name for the Database Cloud Service instance. Default value is ORCL.
+
+* `source_service_name` - (Optional) Indicates that the service instance should be created as a "snapshot clone" of another service instance. Provide the name of the existing service instance whose snapshot is to be used.
+
+* `snapshot_name` - (Optional) The name of the snapshot of the service instance specified by sourceServiceName that is to be used to create a "snapshot clone". This parameter is valid only if source_service_name is specified.
+
+* `timezone` - (Optional) Time Zone for the Database Cloud Service instance. Default value is UTC.
+
+* `type` - (Optional) Component type to which the set of parameters applies. Defaults to db
+
+* `db_demo` - (Optional) Indicates whether to include the Demos PDB. Valid values are yes or no.
+
+In addition to the above, the following values are exported:
+
+* `apex_url` - The URL to use to connect to Oracle Application Express on the service instance.
+
+* `backup_supported_version` - The version of cloud tooling for backup and recovery supported by the service instance.
+
+* `compute_site_name` - The Oracle Cloud location housing the service instance.
+
+* `connect_descriptor_with_public_ip` - The connection descriptor for Oracle Net Services (SQL*Net) with IP addresses instead of host names.
+
+* `created_by` - The user name of the Oracle Cloud user who created the service instance.
+
+* `creation_time` - The date-and-time stamp when the service instance was created.
+
+* `current_version` - The Oracle Database version on the service instance, including the patch level.
+
+* `dbaasmonitor_url`- The URL to use to connect to Oracle DBaaS Monitor on the service instance.
+
+* `em_url` - The URL to use to connect to Enterprise Manager on the service instance.
+
+* `glassfish_url` - The URL to use to connect to the Oracle GlassFish Server Administration Console on the service instance.
+
+* `hdg_prem_ip` - Data Guard Role of the on-premise instance in Oracle Hybrid Disaster Recovery configuration.
+
+* `hybrid_dg` - Indicates whether the service instance hosts an Oracle Hybrid Disaster Recovery configuration.
+
+* `identity_domain` - The identity domain housing the service instance.
+
+* `ip_network` - This attribute is only applicable to accounts where regions are supported. The three-part name of an IP network to which the service instance is added. For example: /Compute-identity_domain/user/object
+
+* `ip_reservations` - Groups one or more IP reservations in use on this service instance. This attribute is only applicable to accounts where regions are supported.
+
+* `jaas_instances_using_service` - The Oracle Java Cloud Service instances using this Database Cloud Service instance.
+
+* `listener_port` - The listener port for Oracle Net Services (SQL*Net) connections.
+
+* `num_ip_reservations` - The number of Oracle Compute Service IP reservations assigned to the service instance.
+
+* `num_nodes` - The number of compute nodes in the service instance.
+
+* `rac_database` - Indicates whether the service instance hosts an Oracle RAC database.
+
+* `region` - This attribute is only applicable to accounts where regions are supported. Location where the service instance is provisioned (only for accounts where regions are supported).
+
+* `sm_plugin_version` - The version of the cloud tooling service manager plugin supported by the service instance.
+
+* `total_shared_storage` - For service instances hosting an Oracle RAC database, the size in GB of the storage shared and accessed by the nodes of the RAC database.
+
+* `uri` - The Uniform Resource Identifier for the Service Instance
+
+## Import
+
+Service Instance's can be imported using the `resource name`, e.g.
+
+```shell
+$ terraform import opc_database_service_instance.instance1 example
+```

--- a/website/docs/r/opc_database_service_instance.html.markdown
+++ b/website/docs/r/opc_database_service_instance.html.markdown
@@ -52,45 +52,28 @@ The following arguments are supported:
 
 * `parameter` - (Optional) Additional configuration for a service instance. This set is required if level is PAAS. Parameter is documented below.
 
+* `ibkup` - (Optional) Specify if the service instance's database should, after the instance is created, be replaced by a database stored in an existing cloud backup that was created using Oracle Database Backup Cloud Service. IBKUP is documented below.
+
+* `cloud_storage` - (Optional) Provides Cloud Storage for service instance backups. Cloud Storage
+is documented below
+
 * `description` - (Optional) A description of the Service Instance.
 
 Parameter supports the following:
 
-* `admin_password` - (Required) Password for Oracle Database administrator users sys and system. The password must meet the following requirements: Starts with a letter. Is between 8 and 30 characters long. Contains letters, at least one number, and optionally, any number of these special characters: dollar sign ($), pound sign (#), and underscore ( _ )
+* `admin_password` - (Required) Password for Oracle Database administrator users sys and system. The password must meet the following requirements: Starts with a letter. Is between 8 and 30 characters long. Contains letters, at least one number, and optionally, any number of these special characters: dollar sign `$`, pound sign `#`, and underscore `_`.
 
 * `backup_destination` - (Required) Backup Destination. Possible values are `BOTH`, `OSS`, `NONE`.
 
 * `char_set` - (Required) Character Set for the Database Cloud Service Instance. All possible values are listed under the [parameters section documentation](http://docs.oracle.com/en/cloud/paas/database-dbaas-cloud/csdbr/op-paas-service-dbcs-api-v1.1-instances-%7BidentityDomainId%7D-post.html). Default value is `AL32UTF8`.
 
-`usable_storage` - (Required) Storage size for data (in GB). Minimum value is `15`. Maximum value depends on the backup destination: if `BOTH` is specified, the maximum value is `1200`; if `OSS` or `NONE` is specified, the maximum value is `2048`.
-
-* `cloud_storage_container` - (Optional) Name of the Oracle Storage Cloud Service container used to provide storage for your service instance backups. Use the following format to specify the container name: `<storageservicename>-<storageidentitydomain>/<containername>`
-
-* `cloud_storage_username` - (Optional) Username for the Oracle Storage Cloud Service administrator.
-
-* `cloud_storage_password` - (Optional) Password for the Oracle Storage Cloud Service administrator.
-
-* `create_storage_container_if_missing` - (Optional) Specify if the given cloud_storage_container is to be created if it does not already exist. Default value is `false`.
+* `usable_storage` - (Required) Storage size for data (in GB). Minimum value is `15`. Maximum value depends on the backup destination: if `BOTH` is specified, the maximum value is `1200`; if `OSS` or `NONE` is specified, the maximum value is `2048`.
 
 * `disaster_recovery` - (Optional) Specify if an Oracle Data Guard configuration is created using the Disaster Recovery option or the High Availability option. Valid values are `yes` and `no`. Default value is no.
 
 * `failover_database` - Specify if an Oracle Data Guard configuration comprising a primary database and a standby database is created. Valid values are `yes` and `no`. Default value is `no`.
 
 * `golden_gate` - (Optional) Specify if the database should be configured for use as the replication database of an Oracle GoldenGate Cloud Service instance. Valid values are `yes` and `no`. Default value is `no`. You cannot set `goldenGate` to `yes` if either `is_rac` or `failoverDatabase` is set to `yes`.
-
-* `ibkup` - (Optional) Specify if the service instance's database should, after the instance is created, be replaced by a database stored in an existing cloud backup that was created using Oracle Database Backup Cloud Service. Valid values are `yes` and `no`. Default value is `no`.
-
-* `ibkup_cloud_storage_username` - (Optional)
-Username of the Oracle Cloud user. This parameter is required if `ibkup` is set to `yes`.
-
-* `ibkup_cloud_storage_password` - (Optional)
-Password of the Oracle Cloud user specified in `ibkup_cloud_storage_user`. This parameter is required if `ibkup` is set to yes.
-
-* `ibkup_database_id` - (Optional) Database id of the database from which the existing cloud backup was created. This parameter is required if `ibkup` is set to `yes`.
-
-* `ibkup_decryption_key` - (Optional) Password used to create the existing, password-encrypted cloud backup. This password is used to decrypt the backup. Specify either `ibkup_decryption_key` or `ibkup_wallet_file_content` for decrypting the backup. This parameter is required if `ibkup` is set to `yes`.
-
-* `ibkup_wallet_file_content` - (Optional) String containing the xsd:base64Binary representation of the cloud backup's wallet file. This wallet is used to decrypt the backup. Specify either `ibkup_decryption_key` or `ibkup_wallet_file_content` for decrypting the backup. This parameter is required if `ibkup` is set to yes.
 
 * `is_rac` - (Optional) Specify if a cluster database using Oracle Real Application Clusters should be configured. Valid values are `yes` and `no`. Default value is `no`.
 
@@ -109,6 +92,29 @@ Password of the Oracle Cloud user specified in `ibkup_cloud_storage_user`. This 
 * `type` - (Optional) Component type to which the set of parameters applies. Defaults to `db`
 
 * `db_demo` - (Optional) Indicates whether to include the Demos PDB. Valid values are `yes` or `no`.
+
+IBKUP supports the following:
+
+* `cloud_storage_username` - (Required) Username of the Oracle Cloud user.
+
+* `cloud_storage_password` - (Required) Password of the Oracle Cloud user specified in `ibkup_cloud_storage_user`.
+
+* `database_id` - (Required) Database id of the database from which the existing cloud backup was created.
+
+* `decryption_key` - (Optional) Password used to create the existing, password-encrypted cloud backup. This password is used to decrypt the backup. Specify either `ibkup_decryption_key` or `ibkup_wallet_file_content` for decrypting the backup.
+
+* `wallet_file_content` - (Optional) String containing the xsd:base64Binary representation of the cloud backup's wallet file. This wallet is used to decrypt the backup. Specify either `ibkup_decryption_key` or `ibkup_wallet_file_content` for decrypting the backup.
+
+Cloud Storage supports the following:
+
+* `container` - (Required) Name of the Oracle Storage Cloud Service container used to provide storage for your service instance backups. Use the following format to specify the container name: `<storageservicename>-<storageidentitydomain>/<containername>`
+
+* `username` - (Required) Username for the Oracle Storage Cloud Service administrator.
+
+* `password` - (Required) Password for the Oracle Storage Cloud Service administrator.
+
+* `create_if_missing` - (Optional) Specify if the given cloud_storage_container is to be created if it does not already exist. Default value is `false`.
+
 
 In addition to the above, the following values are exported:
 


### PR DESCRIPTION
This PR adds Database service instances to the Terraform Provider
https://docs.oracle.com/en/cloud/paas/database-dbaas-cloud/csdbr/api-Service%20Instances.html

```
make testacc TEST=./opc TESTARGS="-run=TestAccOPCDatabaseServiceInstance"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCDatabaseServiceInstance -timeout 120m
=== RUN   TestAccOPCDatabaseServiceInstance_Basic
--- PASS: TestAccOPCDatabaseServiceInstance_Basic (1666.37s)
PASS
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCDatabaseServiceInstance_importBasic -timeout 120m
=== RUN   TestAccOPCDatabaseServiceInstance_importBasic
--- PASS: TestAccOPCDatabaseServiceInstance_importBasic (1914.72s)
PASS
```