### PR TITLE
d/image_list_entry: Adds image_list_entry data source

### DIFF
--- a/opc/data_source_image_list_entry.go
+++ b/opc/data_source_image_list_entry.go
@@ -94,7 +94,7 @@ func dataSourceImageListEntryRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// Populate schema attributes
-	d.SetId(fmt.Sprintf("%s|%s:%d", image_list, version, entry))
+	d.SetId(fmt.Sprintf("%s|%d:%d", image_list, version, entry))
 	d.Set("uri", result.Uri)
 	if err := d.Set("attributes", attrs); err != nil {
 		return err

--- a/opc/data_source_image_list_entry.go
+++ b/opc/data_source_image_list_entry.go
@@ -1,0 +1,107 @@
+package opc
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-oracle-terraform/compute"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+)
+
+func dataSourceImageListEntry() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceImageListEntryRead,
+
+		Schema: map[string]*schema.Schema{
+			"entry": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
+			"image_list": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"version": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			// Computed Attributes
+			"attributes": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"machine_images": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceImageListEntryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*OPCClient).computeClient.ImageListEntries()
+
+	// Get required attributes
+	image_list := d.Get("image_list").(string)
+	version := d.Get("version").(int)
+
+	// Get the image list (we'll parse out the entry later on)
+	input := compute.GetImageListEntryInput{
+		Name:    image_list,
+		Version: version,
+	}
+
+	result, err := client.GetImageListEntry(&input)
+	if err != nil {
+		return err
+	}
+
+	// Not found, don't error
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	// If entry was specified, only return the single entry, otherwise the entire list
+	var images []string
+	var entry int
+	if v, ok := d.GetOk("entry"); ok {
+		entry = v.(int)
+		// Protect against index panic
+		if len(result.MachineImages) <= entry-1 {
+			return fmt.Errorf("Invalid entry specified. Image list only has %d entries, got: %d",
+				len(result.MachineImages), entry)
+		}
+		images = append(images, result.MachineImages[entry-1])
+	} else {
+		images = result.MachineImages
+	}
+
+	// Flatten JSON attributes
+	attrs, err := structure.FlattenJsonToString(result.Attributes)
+	if err != nil {
+		return err
+	}
+
+	// Populate schema attributes
+	d.SetId(fmt.Sprintf("%s|%s:%d", image_list, version, entry))
+	d.Set("uri", result.Uri)
+	if err := d.Set("attributes", attrs); err != nil {
+		return err
+	}
+	if err := d.Set("machine_images", images); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/opc/data_source_image_list_entry_test.go
+++ b/opc/data_source_image_list_entry_test.go
@@ -1,0 +1,103 @@
+package opc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOPCDataSourceImageListEntry_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+	resName := "data.opc_compute_image_list_entry.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceImageListEntryBasic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "machine_images.#", "3"),
+					resource.TestCheckResourceAttr(resName, "machine_images.1",
+						"/oracle/public/oel_6.7_apaas_16.4.5_1610211300"),
+					resource.TestCheckResourceAttr(resName, "machine_images.2",
+						"/oracle/public/OL_5.11_UEKR2_i386-17.2.2-20170405-205607"),
+					resource.TestCheckResourceAttr(resName, "version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOPCDataSourceImageListEntry_entry(t *testing.T) {
+	rInt := acctest.RandInt()
+	resName := "data.opc_compute_image_list_entry.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceImageListEntry_entry(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "machine_images.#", "1"),
+					resource.TestCheckResourceAttr(resName, "machine_images.0",
+						"/oracle/public/OL_5.11_UEKR2_i386-17.2.2-20170405-205607"),
+					resource.TestCheckResourceAttr(resName, "version", "1"),
+					resource.TestCheckResourceAttr(resName, "entry", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceImageListEntryBasic(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_image_list" "test" {
+ name        = "test-acc-image-list-entry-basic-%d"
+ description = "Acceptance Test TestAccOPCImageListEntry_Basic"
+ default     = 1
+}
+
+resource "opc_compute_image_list_entry" "test" {
+  name           = "${opc_compute_image_list.test.name}"
+  machine_images = [
+    "/oracle/public/oel_6.7_apaas_16.4.5_1610211300",
+    "/oracle/public/oel_6.7_apaas_16.4.5_1610211300",
+    "/oracle/public/OL_5.11_UEKR2_i386-17.2.2-20170405-205607"
+  ]
+  version        = 1
+}
+
+data "opc_compute_image_list_entry" "test" {
+  image_list = "${opc_compute_image_list_entry.test.name}"
+  version    = 1
+}`, rInt)
+}
+
+func testAccDataSourceImageListEntry_entry(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_image_list" "test" {
+ name        = "test-acc-image-list-entry-basic-%d"
+ description = "Acceptance Test TestAccOPCImageListEntry_Basic"
+ default     = 1
+}
+
+resource "opc_compute_image_list_entry" "test" {
+  name           = "${opc_compute_image_list.test.name}"
+  machine_images = [
+    "/oracle/public/oel_6.7_apaas_16.4.5_1610211300",
+    "/oracle/public/oel_6.7_apaas_16.4.5_1610211300",
+    "/oracle/public/OL_5.11_UEKR2_i386-17.2.2-20170405-205607"
+  ]
+  version        = 1
+}
+
+data "opc_compute_image_list_entry" "test" {
+  image_list = "${opc_compute_image_list_entry.test.name}"
+  version    = 1
+  entry      = 3
+}`, rInt)
+}

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -59,9 +59,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"opc_compute_image_list_entry":        dataSourceImageListEntry(),
 			"opc_compute_network_interface":       dataSourceNetworkInterface(),
-			"opc_compute_vnic":                    dataSourceVNIC(),
 			"opc_compute_storage_volume_snapshot": dataSourceStorageVolumeSnapshot(),
+			"opc_compute_vnic":                    dataSourceVNIC(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/opc_compute_image_list_entry.html.markdown
+++ b/website/docs/d/opc_compute_image_list_entry.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "opc"
+page_title: "Oracle: opc_compute_image_list_entry"
+sidebar_current: "docs-opc-datasource-image-list-entry"
+description: |-
+  Gets information about the configuration of an Image List Entry in an OPC identity domain
+---
+
+# opc\_compute\_image\_list\_entry
+
+Use this data source to access the configuration of an Image List Entry.
+
+## Example Usage
+
+```hcl
+data "opc_compute_image_list_entry" "foo" {
+  image_list = "my_image_list"
+  version = "version_of_my_list"
+}
+
+output "machine_images" {
+  value = "${data.opc_compute_image_list_entry.foo.machine_images}"
+}
+
+output "single_image" {
+  value = "${data.opc_compute_image_list_entry.foo.machine_images[1]}"
+}
+```
+
+## Argument Reference
+* `image_list` - (Required) - The name of the image list to lookup.
+* `version` - (Required) - The version (integer) of the Image List to use.
+* `entry` - (Optional) - Which machine image to use. See [Entry](#entry) below for more details
+
+## Entry
+The `entry` argument is fully optional when configuring the Data Source. If specified, however,
+the returned array of machine images will have a length of 1, and only contain the desired image.
+
+Thus, if "my_image_list" is an image list that contains the following images:
+
+```
+["image1", "image2", "image3", "image4", "image5"]
+```
+
+Then specifing an `entry` of `3`, the returned `machine_images` array will have a sigle element:
+`"image3"`. If `entry` was omitted, or set to `0`, the returned `machine_images` array will contain
+all of the images for that image list version.
+
+If the supplied `entry` value is invalid for the image list, Terraform will exit with an error,
+that the desired image list entry was not found.
+
+## Attributes Reference
+
+* `dns` - Array of DNS servers for the interface.
+* `attributes` - JSON object of all of the image list's attributes
+* `machine_images` - An array of machine images as strings
+* `uri` - The URI of the image list

--- a/website/opc.erb
+++ b/website/opc.erb
@@ -14,6 +14,9 @@
                 <li<%= sidebar_current("docs-opc-datasource") %>>
                 <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-opc-datasource-image-list-entry") %>>
+                            <a href="/docs/providers/opc/d/opc_compute_image_list_entry.html">opc_compute_image_list_entry</a>
+                        </li>
                         <li<%= sidebar_current("docs-opc-datasource-network-interface") %>>
                             <a href="/docs/providers/opc/d/opc_compute_network_interface.html">opc_compute_network_interface</a>
                         </li>


### PR DESCRIPTION
Adds the image list entry data source

```
$ make testacc TEST=./opc TESTARGS="-run=TestAccOPCDataSourceImageListEntry"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCDataSourceImageListEntry -timeout 120m
=== RUN   TestAccOPCDataSourceImageListEntry_basic
--- PASS: TestAccOPCDataSourceImageListEntry_basic (21.75s)
=== RUN   TestAccOPCDataSourceImageListEntry_entry
--- PASS: TestAccOPCDataSourceImageListEntry_entry (14.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opc/opc	36.541s
```

Fixes: #45 