### PR TITLE
r/vnic_set: Make `virtual_nics` Computed

### DIFF
--- a/opc/resource_vnic_set.go
+++ b/opc/resource_vnic_set.go
@@ -36,6 +36,7 @@ func resourceOPCVNICSet() *schema.Resource {
 			"virtual_nics": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"tags": {


### PR DESCRIPTION
Allows for virtual_nics to be populated during instance creation.

```
$ make testacc TEST=./opc TESTARGS="-run=TestAccOPCVNICSet_UpdateFromInstance"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCVNICSet_UpdateFromInstance -timeout 120m
=== RUN   TestAccOPCVNICSet_UpdateFromInstance
--- PASS: TestAccOPCVNICSet_UpdateFromInstance (86.12s)
PASS
ok      github.com/terraform-providers/terraform-provider-opc/opc       86.124s
```

Fixes: #51 