### PR TITLE
r/opc_storage_object: Add `opc_storage_object` resource

### DIFF
--- a/opc/import_opc_storage_object_test.go
+++ b/opc/import_opc_storage_object_test.go
@@ -1,0 +1,32 @@
+package opc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOPCStorageObject_importBasic(t *testing.T) {
+	rName := "opc_storage_object.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOPCStorageObject_contentSource(rInt, _SourceInput),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"transaction_id", "content"},
+			},
+		},
+	})
+}

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -97,6 +97,7 @@ func Provider() terraform.ResourceProvider {
 			"opc_compute_ip_address_association":  resourceOPCIPAddressAssociation(),
 			"opc_compute_snapshot":                resourceOPCSnapshot(),
 			"opc_storage_container":               resourceOPCStorageContainer(),
+			"opc_storage_object":                  resourceOPCStorageObject(),
 			"opc_database_service_instance":       resourceOPCDatabaseServiceInstance(),
 		},
 

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -5,6 +5,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+const StorageClientInitError = "Storage client is not initialized. Make sure to use `storage_endpoint` variable or the `OPC_STORAGE_ENDPOINT` environment variable"
+
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{

--- a/opc/resource_storage_object.go
+++ b/opc/resource_storage_object.go
@@ -16,7 +16,9 @@ func resourceOPCStorageObject() *schema.Resource {
 		Create: resourceOPCStorageObjectCreate,
 		Read:   resourceOPCStorageObjectRead,
 		Delete: resourceOPCStorageObjectDelete,
-		// TODO: Add Import
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/opc/resource_storage_object.go
+++ b/opc/resource_storage_object.go
@@ -60,6 +60,7 @@ func resourceOPCStorageObject() *schema.Resource {
 			"content_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "Set the MIME type for the object",
 			},
@@ -145,7 +146,7 @@ func resourceOPCStorageObject() *schema.Resource {
 func resourceOPCStorageObjectCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*OPCClient).storageClient.Objects()
 	if client == nil {
-		return fmt.Errorf("Storage client is not initialized. Make sure to use `storage_endpoint` variable or the `OPC_STORAGE_ENDPOINT` environment variable")
+		return fmt.Errorf(StorageClientInitError)
 	}
 
 	// Populate required attr
@@ -175,7 +176,7 @@ func resourceOPCStorageObjectCreate(d *schema.ResourceData, meta interface{}) er
 		input.CopyFrom = v.(string)
 	} else {
 		// One of the three attributes are required
-		return fmt.Errorf("Must specify %q, %q, or %q field", "file", "copy_from", "content")
+		return fmt.Errorf("Must specify `file`, `copy_from`, or `content` field")
 	}
 
 	if v, ok := d.GetOk("content_disposition"); ok {
@@ -214,7 +215,7 @@ func resourceOPCStorageObjectCreate(d *schema.ResourceData, meta interface{}) er
 func resourceOPCStorageObjectRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*OPCClient).storageClient.Objects()
 	if client == nil {
-		return fmt.Errorf("Storage client is not initialized. Make sure to use `storage_endpoint` variable or the `OPC_STORAGE_ENDPOINT` environment variable")
+		return fmt.Errorf(StorageClientInitError)
 	}
 
 	input := &storage.GetObjectInput{
@@ -251,7 +252,7 @@ func resourceOPCStorageObjectRead(d *schema.ResourceData, meta interface{}) erro
 func resourceOPCStorageObjectDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*OPCClient).storageClient.Objects()
 	if client == nil {
-		return fmt.Errorf("Storage client is not initialized. Make sure to use `storage_endpoint` variable or the `OPC_STORAGE_ENDPOINT` environment variable")
+		return fmt.Errorf(StorageClientInitError)
 	}
 
 	input := &storage.DeleteObjectInput{

--- a/opc/resource_storage_object.go
+++ b/opc/resource_storage_object.go
@@ -1,0 +1,265 @@
+package opc
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/go-oracle-terraform/storage"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/mitchellh/go-homedir"
+)
+
+func resourceOPCStorageObject() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOPCStorageObjectCreate,
+		Read:   resourceOPCStorageObjectRead,
+		Delete: resourceOPCStorageObjectDelete,
+		// TODO: Add Import
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the storage object",
+			},
+			"container": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the storage container",
+			},
+			"content": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Description:   "Raw content in string-form of the data",
+				ConflictsWith: []string{"copy_from", "file"},
+			},
+			"file": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Description:   "File path for the content to use for data",
+				ConflictsWith: []string{"copy_from", "content"},
+			},
+			"content_disposition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Overrides the behavior of the browser",
+			},
+			"content_encoding": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Set the content-encoding metadata",
+			},
+			"content_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Set the MIME type for the object",
+			},
+			"copy_from": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"content", "file"},
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !strings.Contains(value, "/") {
+						errors = append(errors, fmt.Errorf(
+							"%q does not contain both a container and object name",
+							k))
+					}
+					return
+				},
+			},
+			"delete_at": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Specify the number of seconds after which the system deletes the object",
+			},
+			"etag": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "MD5 checksum value of the request body. Unquoted. Strongly Recommended",
+			},
+			"transfer_encoding": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Sets the transfer encoding. Can only be 'chunked' or Nil, requires Content-Length to be 0 if set",
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if value != "chunked" {
+						errors = append(errors, fmt.Errorf(
+							"%q must be either 'chunked' or nil", k))
+					}
+					return
+				},
+			},
+
+			// Computed Attributes
+			"accept_ranges": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of ranges that the object accepts",
+			},
+			"content_length": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Length of the object in bytes",
+			},
+			"last_modified": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date and Time that the object was created/modified in ISO 8601",
+			},
+			"object_manifest": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The dynamic large-object manifest object",
+			},
+			"timestamp": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date and Time in UNIX EPOCH when the account, container, or object was initially created at the current version",
+			},
+			"transaction_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Transaction ID of the request. Used for bug reports",
+			},
+		},
+	}
+}
+
+func resourceOPCStorageObjectCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*OPCClient).storageClient.Objects()
+	if client == nil {
+		return fmt.Errorf("Storage client is not initialized. Make sure to use `storage_endpoint` variable or the `OPC_STORAGE_ENDPOINT` environment variable")
+	}
+
+	// Populate required attr
+	input := &storage.CreateObjectInput{
+		Name:      d.Get("name").(string),
+		Container: d.Get("container").(string),
+	}
+
+	// Check for `content` or `file`.
+	if v, ok := d.GetOk("content"); ok {
+		// Read content as io.ReadSeeker
+		content := v.(string)
+		input.Body = bytes.NewReader([]byte(content))
+	} else if v, ok := d.GetOk("file"); ok {
+		// Read raw file
+		source := v.(string)
+		path, err := homedir.Expand(source)
+		if err != nil {
+			return fmt.Errorf("Error expanding homedir in file (%s): %s", source, err)
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("Error opening Storage Object file (%s): %s", source, err)
+		}
+		input.Body = file
+	} else if v, ok := d.GetOk("copy_from"); ok {
+		input.CopyFrom = v.(string)
+	} else {
+		// One of the three attributes are required
+		return fmt.Errorf("Must specify %q, %q, or %q field", "file", "copy_from", "content")
+	}
+
+	if v, ok := d.GetOk("content_disposition"); ok {
+		input.ContentDisposition = v.(string)
+	}
+
+	if v, ok := d.GetOk("content_encoding"); ok {
+		input.ContentEncoding = v.(string)
+	}
+
+	if v, ok := d.GetOk("content_type"); ok {
+		input.ContentType = v.(string)
+	}
+
+	if v, ok := d.GetOk("delete_at"); ok {
+		input.DeleteAt = v.(int)
+	}
+
+	if v, ok := d.GetOk("etag"); ok {
+		input.ETag = v.(string)
+	}
+
+	if v, ok := d.GetOk("transfer_encoding"); ok {
+		input.TransferEncoding = v.(string)
+	}
+
+	result, err := client.CreateObject(input)
+	if err != nil {
+		return fmt.Errorf("Error creating Object: %s", err)
+	}
+
+	d.SetId(result.ID)
+	return resourceOPCStorageObjectRead(d, meta)
+}
+
+func resourceOPCStorageObjectRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*OPCClient).storageClient.Objects()
+	if client == nil {
+		return fmt.Errorf("Storage client is not initialized. Make sure to use `storage_endpoint` variable or the `OPC_STORAGE_ENDPOINT` environment variable")
+	}
+
+	input := &storage.GetObjectInput{
+		ID: d.Id(),
+	}
+
+	result, err := client.GetObject(input)
+	if err != nil {
+		return fmt.Errorf("Error reading Storage Container Object (%s): %s", d.Id(), err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", result.Name)
+	d.Set("container", result.Container)
+	d.Set("content_disposition", result.ContentDisposition)
+	d.Set("content_encoding", result.ContentEncoding)
+	d.Set("content_length", result.ContentLength)
+	d.Set("content_type", result.ContentType)
+	d.Set("date", result.Date)
+	d.Set("etag", result.Etag)
+	d.Set("last_modified", result.LastModified)
+	d.Set("delete_at", result.DeleteAt)
+	d.Set("object_manifest", result.ObjectManifest)
+	d.Set("timestamp", result.Timestamp)
+	d.Set("transaction_id", result.TransactionID)
+
+	return nil
+}
+
+func resourceOPCStorageObjectDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*OPCClient).storageClient.Objects()
+	if client == nil {
+		return fmt.Errorf("Storage client is not initialized. Make sure to use `storage_endpoint` variable or the `OPC_STORAGE_ENDPOINT` environment variable")
+	}
+
+	input := &storage.DeleteObjectInput{
+		ID: d.Id(),
+	}
+	if err := client.DeleteObject(input); err != nil {
+		return fmt.Errorf("Error deleting Storage Container Object (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/opc/resource_storage_object_test.go
+++ b/opc/resource_storage_object_test.go
@@ -41,6 +41,35 @@ func TestAccOPCStorageObject_contentSource(t *testing.T) {
 	})
 }
 
+func TestAccOPCStorageObject_contentSource_nilContentType(t *testing.T) {
+	resName := "opc_storage_object.test"
+	rInt := acctest.RandInt()
+
+	body := _SourceInput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOPCStorageObject_contentSource_nilContentType(rInt, body),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageObjectExists,
+					resource.TestCheckResourceAttr(resName, "name", fmt.Sprintf("test-acc-%d", rInt)),
+					resource.TestCheckResourceAttr(resName, "container", fmt.Sprintf("acc-test-%d", rInt)),
+					resource.TestCheckResourceAttrSet(resName, "content_length"),
+					resource.TestCheckResourceAttrSet(resName, "content_type"),
+					resource.TestCheckResourceAttr(resName, "delete_at", "0"),
+					resource.TestCheckResourceAttrSet(resName, "last_modified"),
+					resource.TestCheckResourceAttrSet(resName, "timestamp"),
+					resource.TestCheckResourceAttrSet(resName, "transaction_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOPCStorageObject_fileSource(t *testing.T) {
 	resName := "opc_storage_object.test"
 	rInt := acctest.RandInt()
@@ -125,6 +154,22 @@ resource "opc_storage_object" "test" {
   name = "test-acc-%d"
   container = "${opc_storage_container.foo.name}"
   content_type = "text/plain;charset=UTF-8"
+  content = <<EOF
+%s
+EOF
+}`,
+		testAccOPCStorageObject_testContainer(rInt),
+		rInt,
+		body)
+}
+
+func testAccOPCStorageObject_contentSource_nilContentType(rInt int, body string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opc_storage_object" "test" {
+  name = "test-acc-%d"
+  container = "${opc_storage_container.foo.name}"
   content = <<EOF
 %s
 EOF

--- a/opc/resource_storage_object_test.go
+++ b/opc/resource_storage_object_test.go
@@ -1,0 +1,173 @@
+package opc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/storage"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const _TestStorageObjectPath = "test-fixtures"
+
+func TestAccOPCStorageObject_contentSource(t *testing.T) {
+	resName := "opc_storage_object.test"
+	rInt := acctest.RandInt()
+
+	body := _SourceInput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOPCStorageObject_contentSource(rInt, body),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageObjectExists,
+					resource.TestCheckResourceAttr(resName, "name", fmt.Sprintf("test-acc-%d", rInt)),
+					resource.TestCheckResourceAttr(resName, "container", fmt.Sprintf("acc-test-%d", rInt)),
+					resource.TestCheckResourceAttrSet(resName, "content_length"),
+					resource.TestCheckResourceAttr(resName, "content_type", "text/plain;charset=UTF-8"),
+					resource.TestCheckResourceAttr(resName, "delete_at", "0"),
+					resource.TestCheckResourceAttrSet(resName, "last_modified"),
+					resource.TestCheckResourceAttrSet(resName, "timestamp"),
+					resource.TestCheckResourceAttrSet(resName, "transaction_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOPCStorageObject_fileSource(t *testing.T) {
+	resName := "opc_storage_object.test"
+	rInt := acctest.RandInt()
+
+	path := _TestStorageObjectPath + "/fileSource.txt"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOPCStorageObject_fileSource(rInt, path),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageObjectExists,
+					resource.TestCheckResourceAttr(resName, "name", fmt.Sprintf("test-acc-%d", rInt)),
+					resource.TestCheckResourceAttr(resName, "container", fmt.Sprintf("acc-test-%d", rInt)),
+					resource.TestCheckResourceAttrSet(resName, "content_length"),
+					resource.TestCheckResourceAttr(resName, "content_type", "text/plain;charset=UTF-8"),
+					resource.TestCheckResourceAttr(resName, "delete_at", "0"),
+					resource.TestCheckResourceAttrSet(resName, "last_modified"),
+					resource.TestCheckResourceAttrSet(resName, "timestamp"),
+					resource.TestCheckResourceAttrSet(resName, "transaction_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckStorageObjectExists(s *terraform.State) error {
+	client := testAccProvider.Meta().(*OPCClient).storageClient.Objects()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opc_storage_object" {
+			continue
+		}
+
+		input := &storage.GetObjectInput{
+			ID: rs.Primary.Attributes["id"],
+		}
+		if _, err := client.GetObject(input); err != nil {
+			return fmt.Errorf("Error retrieving state of Storage Object (%s): %s", input.ID, err)
+		}
+	}
+	return nil
+}
+
+func testAccCheckStorageObjectDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*OPCClient).storageClient.Objects()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opc_storage_object" {
+			continue
+		}
+
+		input := &storage.GetObjectInput{
+			ID: rs.Primary.Attributes["id"],
+		}
+
+		if info, err := client.GetObject(input); err == nil {
+			return fmt.Errorf("Storage Object (%s) still exists: %#v", input.ID, info)
+		}
+	}
+	return nil
+}
+
+func testAccOPCStorageObject_testContainer(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_storage_container" "foo" {
+  name = "acc-test-%d"
+  max_age = 50
+  primary_key = "test-key"
+  allowed_origins = ["origin-1"]
+}`, rInt)
+}
+
+func testAccOPCStorageObject_contentSource(rInt int, body string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opc_storage_object" "test" {
+  name = "test-acc-%d"
+  container = "${opc_storage_container.foo.name}"
+  content_type = "text/plain;charset=UTF-8"
+  content = <<EOF
+%s
+EOF
+}`,
+		testAccOPCStorageObject_testContainer(rInt),
+		rInt,
+		body)
+}
+
+func testAccOPCStorageObject_fileSource(rInt int, path string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opc_storage_object" "test" {
+  name = "test-acc-%d"
+  container = "${opc_storage_container.foo.name}"
+  content_type = "text/plain;charset=UTF-8"
+  file = "%s"
+}`,
+		testAccOPCStorageObject_testContainer(rInt),
+		rInt,
+		path)
+}
+
+const _SourceInput = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor nisi id sem gravida, quis sollicitudin dolor
+maximus. Sed est lectus, mollis sit amet neque eu, pulvinar aliquet turpis. Aenean in euismod erat. Proin pulvinar
+ex vel lorem malesuada, sed tincidunt urna posuere. Sed fringilla, elit et faucibus maximus, dui orci blandit lectus,
+ullamcorper fringilla felis nisl at nisl. Ut leo elit, semper non dui sit amet, sagittis commodo nulla. Nulla pulvinar
+purus a nunc pellentesque scelerisque at id elit. Etiam quis bibendum eros. Etiam erat elit, feugiat non ante tempus,
+mattis consectetur purus. Cras nunc nibh, fringilla in imperdiet a, tempus porta nisl. Curabitur nec justo nec leo
+luctus scelerisque quis sit amet risus. Curabitur finibus fringilla lacus eu vestibulum. Nunc pellentesque aliquam
+semper. Proin nec ligula urna. Donec lobortis aliquam nunc vitae feugiat. Integer blandit risus in gravida facilisis.
+Pellentesque vitae lectus sed est pretium finibus. Morbi sed lacus purus. Duis nec condimentum urna. Donec vel velit
+purus. Ut a velit risus. Vivamus ac euismod magna, eget convallis quam. Sed tincidunt, nisl nec rhoncus facilisis,
+orci mauris commodo leo, ut eleifend nisi nisi sit amet mauris. Ut lacinia viverra rhoncus. Phasellus lacinia eleifend
+turpis eu rutrum. Donec sed gravida eros, eget molestie ipsum.In hac habitasse platea dictumst. Duis a libero ante.
+Quisque euismod placerat risus sit amet maximus. Praesent malesuada velit nec dui tincidunt rutrum. Proin commodo ex
+non consectetur cursus. Pellentesque egestas pharetra mauris, et condimentum nibh rhoncus nec. Morbi hendrerit vel
+ligula vel varius. Vestibulum in faucibus metus, eget euismod justo. Cras dolor sem, dictum eget scelerisque at,
+scelerisque eu enim. Aliquam vulputate rutrum orci, vitae convallis mauris sollicitudin ut.Quisque eu accumsan massa.
+Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut nisl magna, vulputate eget
+eleifend id, tincidunt eget dolor. Nam pulvinar, dui non pellentesque dignissim, nulla neque iaculis sapien, id commodo
+nisi nunc vel turpis. Vivamus eget dapibus lacus. Mauris convallis mi sit amet faucibus placerat. Mauris gravida neque
+tortor, vel placerat sem elementum venenatis. Integer eu placerat est. Sed sem massa, volutpat eget augue eget, aliquam
+semper sem.`

--- a/opc/test-fixtures/fileSource.txt
+++ b/opc/test-fixtures/fileSource.txt
@@ -1,0 +1,21 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor nisi id sem gravida, quis sollicitudin dolor
+maximus. Sed est lectus, mollis sit amet neque eu, pulvinar aliquet turpis. Aenean in euismod erat. Proin pulvinar
+ex vel lorem malesuada, sed tincidunt urna posuere. Sed fringilla, elit et faucibus maximus, dui orci blandit lectus,
+ullamcorper fringilla felis nisl at nisl. Ut leo elit, semper non dui sit amet, sagittis commodo nulla. Nulla pulvinar
+purus a nunc pellentesque scelerisque at id elit. Etiam quis bibendum eros. Etiam erat elit, feugiat non ante tempus,
+mattis consectetur purus. Cras nunc nibh, fringilla in imperdiet a, tempus porta nisl. Curabitur nec justo nec leo
+luctus scelerisque quis sit amet risus. Curabitur finibus fringilla lacus eu vestibulum. Nunc pellentesque aliquam
+semper. Proin nec ligula urna. Donec lobortis aliquam nunc vitae feugiat. Integer blandit risus in gravida facilisis.
+Pellentesque vitae lectus sed est pretium finibus. Morbi sed lacus purus. Duis nec condimentum urna. Donec vel velit
+purus. Ut a velit risus. Vivamus ac euismod magna, eget convallis quam. Sed tincidunt, nisl nec rhoncus facilisis,
+orci mauris commodo leo, ut eleifend nisi nisi sit amet mauris. Ut lacinia viverra rhoncus. Phasellus lacinia eleifend
+turpis eu rutrum. Donec sed gravida eros, eget molestie ipsum.In hac habitasse platea dictumst. Duis a libero ante.
+Quisque euismod placerat risus sit amet maximus. Praesent malesuada velit nec dui tincidunt rutrum. Proin commodo ex
+non consectetur cursus. Pellentesque egestas pharetra mauris, et condimentum nibh rhoncus nec. Morbi hendrerit vel
+ligula vel varius. Vestibulum in faucibus metus, eget euismod justo. Cras dolor sem, dictum eget scelerisque at,
+scelerisque eu enim. Aliquam vulputate rutrum orci, vitae convallis mauris sollicitudin ut.Quisque eu accumsan massa.
+Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut nisl magna, vulputate eget
+eleifend id, tincidunt eget dolor. Nam pulvinar, dui non pellentesque dignissim, nulla neque iaculis sapien, id commodo
+nisi nunc vel turpis. Vivamus eget dapibus lacus. Mauris convallis mi sit amet faucibus placerat. Mauris gravida neque
+tortor, vel placerat sem elementum venenatis. Integer eu placerat est. Sed sem massa, volutpat eget augue eget, aliquam
+semper sem.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,42 +250,42 @@
 		{
 			"checksumSHA1": "8N/9z3bEh+6LqR9Yfe1+FcjJZDs=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
-			"revisionTime": "2017-08-07T20:01:57Z",
-			"version": "=v0.3.1",
-			"versionExact": "v0.3.1"
+			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
+			"revisionTime": "2017-08-07T22:45:07Z",
+			"version": "v0.3.2",
+			"versionExact": "v0.3.2"
 		},
 		{
 			"checksumSHA1": "KX87DJWFbBPcFhxiMLk7j/O9VLE=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
-			"revisionTime": "2017-08-07T20:01:57Z",
-			"version": "=v0.3.1",
-			"versionExact": "v0.3.1"
+			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
+			"revisionTime": "2017-08-07T22:45:07Z",
+			"version": "v0.3.2",
+			"versionExact": "v0.3.2"
 		},
 		{
 			"checksumSHA1": "PhmW3m7d3kwkT2WjndZiFr1UtNU=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
-			"revisionTime": "2017-08-07T20:01:57Z",
-			"version": "=v0.3.1",
-			"versionExact": "v0.3.1"
+			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
+			"revisionTime": "2017-08-07T22:45:07Z",
+			"version": "v0.3.2",
+			"versionExact": "v0.3.2"
 		},
 		{
 			"checksumSHA1": "JbuYtbJkx3r1BLuCMymkri0Q1BI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
-			"revisionTime": "2017-08-07T20:01:57Z",
-			"version": "=v0.3.1",
-			"versionExact": "v0.3.1"
+			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
+			"revisionTime": "2017-08-07T22:45:07Z",
+			"version": "v0.3.2",
+			"versionExact": "v0.3.2"
 		},
 		{
-			"checksumSHA1": "rzRyfneT06rrYGYIvHEYwICsztU=",
+			"checksumSHA1": "RtiR+U+o+7SXKSstsIJmCtc0DhU=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "ed479c158bbbd73132faf7126cb0e1baaac59b99",
-			"revisionTime": "2017-08-07T20:01:57Z",
-			"version": "=v0.3.1",
-			"versionExact": "v0.3.1"
+			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
+			"revisionTime": "2017-08-07T22:45:07Z",
+			"version": "v0.3.2",
+			"versionExact": "v0.3.2"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/website/docs/r/opc_compute_storage_object.html.markdown
+++ b/website/docs/r/opc_compute_storage_object.html.markdown
@@ -1,0 +1,77 @@
+---
+layout: "opc"
+page_title: "Oracle: opc_storage_object"
+sidebar_current: "docs-opc-resource-storage-object"
+description: |-
+  Creates and manages a Container Object in the OPC Storage Domain. `storage_endpoint` must be set in the
+  provider or environment to manage these resources.
+---
+
+# opc\_storage\_object
+
+Creates and manages a Container in the OPC Storage Domain. `storage_endpoint` must be set in the
+provider or environment to manage these resources.
+
+## Example Usage
+
+```hcl
+resource "opc_storage_container" "foo" {
+  name = "my-storage-container"
+  max_age = 50
+  primary_key = "test-key"
+  allowed_origins = ["origin-1"]
+}
+
+resource "opc_storage_object" "default" {
+  name        = "my-storage-object"
+  container   = "${opc_storage_container.foo.name}"
+  content     = <<EOF
+FOO BAR BAZ
+File Contents that will be supplied as the storage object
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Storage Object.
+
+* `container` - (Required) The name of the Storage Container in which to place the object.
+
+**Note:** One of `content`, `file`, or `copy_from` must be specified
+
+* `content` - (Optional) A raw string value for the Storage Object's contents.
+
+* `file` - (Optional) The path to the file to use as the Storage Object's contents.
+
+* `copy_from` - (Optional) The source Storage Object to copy from. (`container_name/object_name`).
+
+* `content_disposition` - (Optional) Overrides the behavior of the browser.
+
+* `content_encoding` - (Optional) Set the content-encoding metadata for the Storage Object.
+
+* `content_type` - (Optional) Sets the MIME type for the object. Will be computed via the API if not specified.
+
+* `delete_at` - (Optional) Specify the number of seconds after which the system deletes the storage object.
+
+* `etag` - (Optional) MD5 checksum value of the request body. Unquoted, strongly recommended, but not required.
+
+* `transfer_encoding` - (Optional) Sets the transfer encoding. Can only be `chunked` if set. Requires `content_length` to be `0` if set.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `accept_ranges` - Type of ranges that the object accepts.
+
+* `content_length` - Length of the Storage Object in bytes.
+
+* `last_modified` - Date and time that the object was created/modified in ISO 8601.
+
+* `object_manifest` - The dynamic large-object manifest object.
+
+* `timestamp` - Date and Time in UNIX EPOCH when the account, container, or object was initially created at the current version.
+
+* `transaction_id` - Transaction ID of the request. Used for bug reports.

--- a/website/docs/r/opc_compute_storage_object.html.markdown
+++ b/website/docs/r/opc_compute_storage_object.html.markdown
@@ -75,3 +75,14 @@ The following attributes are exported:
 * `timestamp` - Date and Time in UNIX EPOCH when the account, container, or object was initially created at the current version.
 
 * `transaction_id` - Transaction ID of the request. Used for bug reports.
+
+## Import
+
+Storage Object's can be imported using `container_name/object_name`, e.g.
+```shell
+$ terraform import opc_storage_object.test my_container/my_object
+```
+
+Please note though, importing a Storage Object does _not_ allow a user to modify the content, or attributes for the Storage Object.
+It is, however, possible to import a Storage Object, and replace the object with new content, or a copy of another Storage Object.
+It is also possible to import a Storage Object into Terraform in order to delete the object.

--- a/website/opc.erb
+++ b/website/opc.erb
@@ -5,12 +5,9 @@
                 <li<%= sidebar_current("docs-home") %>>
                     <a href="/docs/providers/index.html">All Providers</a>
                 </li>
-
                 <li<%= sidebar_current("docs-opc-index") %>>
                     <a href="/docs/providers/opc/index.html">Oracle Public Cloud Provider</a>
                 </li>
-
-
                 <li<%= sidebar_current("docs-opc-datasource") %>>
                 <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
@@ -29,7 +26,7 @@
                     </ul>
                 </li>
                 <li<%= sidebar_current("docs-opc-resource") %>>
-                <a href="#">Resources</a>
+                <a href="#">Compute Resources</a>
                     <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-opc-resource-acl") %>>
                             <a href="/docs/providers/opc/r/opc_compute_acl.html">opc_compute_acl</a>
@@ -103,10 +100,13 @@
                     </ul>
                 </li>
                <li<%= sidebar_current("docs-opc-paas-resource") %>>
-                <a href="#">PaaS Resources</a>
+                <a href="#">Storage PAAS Resources</a>
                     <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-opc-resource-storage-container") %>>
                             <a href="/docs/providers/opc/r/opc_storage_container.html">opc_storage_container</a>
+                        </li>
+                        <li<%= sidebar_current("docs-opc-resource-storage-object") %>>
+                            <a href="/docs/providers/opc/r/opc_storage_object.html">opc_storage_object</a>
                         </li>
                     </ul>
                 </li>


### PR DESCRIPTION
Still need to add timeouts to the resource, but those can be added later.
Also need to add Import and Import test

```
$ make testacc TEST=./opc TESTARGS="-run=TestAccOPCStorageObject"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCStorageObject -timeout 120m
=== RUN   TestAccOPCStorageObject_contentSource
--- PASS: TestAccOPCStorageObject_contentSource (17.08s)
=== RUN   TestAccOPCStorageObject_fileSource
--- PASS: TestAccOPCStorageObject_fileSource (12.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-opc/opc       29.577s
```