### PR TITLE
B containers allowed origin

### DIFF
--- a/opc/resource_storage_container.go
+++ b/opc/resource_storage_container.go
@@ -41,6 +41,12 @@ func resourceOPCStorageContainer() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"exposed_headers": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"primary_key": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -74,6 +80,9 @@ func resourceOPCStorageContainerCreate(d *schema.ResourceData, meta interface{})
 	}
 	if allowedOrigins := getStringList(d, "allowed_origins"); len(allowedOrigins) > 0 {
 		input.AllowedOrigins = allowedOrigins
+	}
+	if exposedHeaders := getStringList(d, "exposed_headers"); len(exposedHeaders) > 0 {
+		input.ExposedHeaders = exposedHeaders
 	}
 	if primaryKey, ok := d.GetOk("primary_key"); ok {
 		input.PrimaryKey = primaryKey.(string)
@@ -134,6 +143,9 @@ func resourceOPCStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 	if err := setStringList(d, "allowed_origins", result.AllowedOrigins); err != nil {
 		return err
 	}
+	if err := setStringList(d, "exposed_headers", result.ExposedHeaders); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -172,6 +184,9 @@ func resourceOPCStorageContainerUpdate(d *schema.ResourceData, meta interface{})
 	}
 	if allowedOrigins := getStringList(d, "allowed_origins"); len(allowedOrigins) > 0 {
 		input.AllowedOrigins = allowedOrigins
+	}
+	if exposedHeaders := getStringList(d, "exposed_headers"); len(exposedHeaders) > 0 {
+		input.ExposedHeaders = exposedHeaders
 	}
 	if primaryKey, ok := d.GetOk("primary_key"); ok {
 		input.PrimaryKey = primaryKey.(string)

--- a/opc/resource_storage_container_test.go
+++ b/opc/resource_storage_container_test.go
@@ -51,6 +51,8 @@ func TestAccOPCStorageContainer_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(containerResourceName, "primary_key", "test-key"),
 					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.#", "1"),
 					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.0", "origin-1"),
+					resource.TestCheckResourceAttr(containerResourceName, "exposed_headers.#", "1"),
+					resource.TestCheckResourceAttr(containerResourceName, "exposed_headers.0", "exposed-header-1"),
 				),
 			},
 			{
@@ -62,6 +64,8 @@ func TestAccOPCStorageContainer_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(containerResourceName, "secondary_key", "test-key"),
 					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.#", "2"),
 					resource.TestCheckResourceAttr(containerResourceName, "allowed_origins.1", "origin-2"),
+					resource.TestCheckResourceAttr(containerResourceName, "exposed_headers.#", "2"),
+					resource.TestCheckResourceAttr(containerResourceName, "exposed_headers.1", "exposed-header-2"),
 				),
 			},
 		},
@@ -112,6 +116,7 @@ resource "opc_storage_container" "test" {
   max_age = 50
   primary_key = "test-key"
   allowed_origins = ["origin-1"]
+	exposed_headers = ["exposed-header-1"]
 }
 `
 
@@ -122,5 +127,6 @@ resource "opc_storage_container" "test" {
   primary_key = "test-key-updated"
   secondary_key = "test-key"
   allowed_origins = ["origin-1", "origin-2"]
+	exposed_headers = ["exposed-header-1", "exposed-header-2"]
 }
 `

--- a/vendor/github.com/hashicorp/go-oracle-terraform/storage/container.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/storage/container.go
@@ -20,6 +20,8 @@ type Container struct {
 	SecondaryKey string
 	// List of origins to be allowed to make cross-origin Requests.
 	AllowedOrigins []string
+	// List of headers exposed to the user agent (e.g. browser) in the actual request response.
+	ExposedHeaders []string
 	// Maximum age in seconds for the origin to hold the preflight results.
 	MaxAge int
 }
@@ -47,6 +49,9 @@ type CreateContainerInput struct {
 	// Sets the list of origins allowed to make cross-origin requests.
 	// Optional
 	AllowedOrigins []string
+	// List of headers exposed to the user agent (e.g. browser) in the actual request response.
+	// Optional
+	ExposedHeaders []string
 	// Sets the maximum age in seconds for the origin to hold the preflight results.
 	// Optional
 	MaxAge int
@@ -68,7 +73,8 @@ func (c *StorageClient) CreateContainer(input *CreateContainerInput) (*Container
 
 	headers["X-Container-Meta-Temp-URL-Key"] = input.PrimaryKey
 	headers["X-Container-Meta-Temp-URL-Key-2"] = input.SecondaryKey
-	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Allow-Origin"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.ExposedHeaders, " ")
 	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(input.MaxAge)
 
 	if err := c.createResource(input.Name, headers); err != nil {
@@ -136,6 +142,9 @@ type UpdateContainerInput struct {
 	// Updates the list of origins allowed to make cross-origin requests.
 	// Optional
 	AllowedOrigins []string
+	// List of headers exposed to the user agent (e.g. browser) in the actual request response.
+	// Optional
+	ExposedHeaders []string
 	// Updates the maximum age in seconds for the origin to hold the preflight results.
 	// Optional
 	MaxAge int
@@ -155,7 +164,8 @@ func (c *StorageClient) UpdateContainer(input *UpdateContainerInput) (*Container
 
 	headers["X-Container-Meta-Temp-URL-Key"] = input.PrimaryKey
 	headers["X-Container-Meta-Temp-URL-Key-2"] = input.SecondaryKey
-	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Allow-Origin"] = strings.Join(input.AllowedOrigins, " ")
+	headers["X-Container-Meta-Access-Control-Expose-Headers"] = strings.Join(input.ExposedHeaders, " ")
 	headers["X-Container-Meta-Access-Control-Max-Age"] = strconv.Itoa(input.MaxAge)
 
 	input.Name = c.getQualifiedName(input.Name)
@@ -175,7 +185,8 @@ func (c *StorageClient) success(rsp *http.Response, container *Container) (*Cont
 	container.WriteACLs = strings.Split(rsp.Header.Get("X-Container-Write"), ",")
 	container.PrimaryKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key")
 	container.SecondaryKey = rsp.Header.Get("X-Container-Meta-Temp-URL-Key-2")
-	container.AllowedOrigins = strings.Split(rsp.Header.Get("X-Container-Meta-Access-Control-Expose-Headers"), " ")
+	container.AllowedOrigins = strings.Split(rsp.Header.Get("X-Container-Meta-Access-Control-Allow-Origin"), " ")
+	container.ExposedHeaders = strings.Split(rsp.Header.Get("X-Container-Meta-Access-Control-Expose-Headers"), " ")
 	container.MaxAge, err = strconv.Atoi(rsp.Header.Get("X-Container-Meta-Access-Control-Max-Age"))
 	if err != nil {
 		return nil, err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,42 +250,42 @@
 		{
 			"checksumSHA1": "8N/9z3bEh+6LqR9Yfe1+FcjJZDs=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
-			"revisionTime": "2017-08-07T22:45:07Z",
-			"version": "v0.3.2",
-			"versionExact": "v0.3.2"
+			"revision": "fdc1d8147734a63632b01a8fb7f5fce947d8501d",
+			"revisionTime": "2017-08-10T15:37:48Z",
+			"version": "=v0.3.3",
+			"versionExact": "v0.3.3"
 		},
 		{
 			"checksumSHA1": "KX87DJWFbBPcFhxiMLk7j/O9VLE=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
-			"revisionTime": "2017-08-07T22:45:07Z",
-			"version": "v0.3.2",
-			"versionExact": "v0.3.2"
+			"revision": "fdc1d8147734a63632b01a8fb7f5fce947d8501d",
+			"revisionTime": "2017-08-10T15:37:48Z",
+			"version": "=v0.3.3",
+			"versionExact": "v0.3.3"
 		},
 		{
 			"checksumSHA1": "PhmW3m7d3kwkT2WjndZiFr1UtNU=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
-			"revisionTime": "2017-08-07T22:45:07Z",
-			"version": "v0.3.2",
-			"versionExact": "v0.3.2"
+			"revision": "fdc1d8147734a63632b01a8fb7f5fce947d8501d",
+			"revisionTime": "2017-08-10T15:37:48Z",
+			"version": "=v0.3.3",
+			"versionExact": "v0.3.3"
 		},
 		{
 			"checksumSHA1": "JbuYtbJkx3r1BLuCMymkri0Q1BI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
-			"revisionTime": "2017-08-07T22:45:07Z",
-			"version": "v0.3.2",
-			"versionExact": "v0.3.2"
+			"revision": "fdc1d8147734a63632b01a8fb7f5fce947d8501d",
+			"revisionTime": "2017-08-10T15:37:48Z",
+			"version": "=v0.3.3",
+			"versionExact": "v0.3.3"
 		},
 		{
-			"checksumSHA1": "RtiR+U+o+7SXKSstsIJmCtc0DhU=",
+			"checksumSHA1": "H8V9Z6p2ezWTQmDkKrcnlIYg8q4=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "e02ce3d09fb71bf76ba4d7a2b737730800bc95fa",
-			"revisionTime": "2017-08-07T22:45:07Z",
-			"version": "v0.3.2",
-			"versionExact": "v0.3.2"
+			"revision": "fdc1d8147734a63632b01a8fb7f5fce947d8501d",
+			"revisionTime": "2017-08-10T15:37:48Z",
+			"version": "=v0.3.3",
+			"versionExact": "v0.3.3"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",


### PR DESCRIPTION
This PR fixes #62 and adds `exposed_origins` to storage containers

```
make testacc TEST=./opc TESTARGS="-run=TestAccOPCStorageContainer"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCStorageContainer -timeout 120m
=== RUN   TestAccOPCStorageContainer_importBasic
--- PASS: TestAccOPCStorageContainer_importBasic (17.95s)
=== RUN   TestAccOPCStorageContainer_Basic
--- PASS: TestAccOPCStorageContainer_Basic (17.43s)
=== RUN   TestAccOPCStorageContainer_Updated
--- PASS: TestAccOPCStorageContainer_Updated (31.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opc/opc	67.111s
```