### PR TITLE
r/opc_compute_image_list_entry: Fix resource imports

### DIFF
--- a/opc/import_image_list_entry_test.go
+++ b/opc/import_image_list_entry_test.go
@@ -1,0 +1,30 @@
+package opc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOPCImageListEntry_importBasic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	rName := "opc_compute_image_list_entry.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckImageListEntryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageListEntry_basic(rInt),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/opc/resource_image_list_entry_test.go
+++ b/opc/resource_image_list_entry_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestAccOPCImageListEntry_Basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccImageListEntry_basic, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,7 +19,7 @@ func TestAccOPCImageListEntry_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckImageListEntryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccImageListEntry_basic(ri),
 				Check:  testAccCheckImageListEntryExists,
 			},
 		},
@@ -112,7 +111,9 @@ func testAccCheckImageListEntryDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccImageListEntry_basic = `
+func testAccImageListEntry_basic(rInt int) string {
+
+	return fmt.Sprintf(`
 resource "opc_compute_image_list" "test" {
   name        = "test-acc-image-list-entry-basic-%d"
   description = "Acceptance Test TestAccOPCImageListEntry_Basic"
@@ -123,8 +124,8 @@ resource "opc_compute_image_list_entry" "test" {
   name           = "${opc_compute_image_list.test.name}"
   machine_images = [ "/oracle/public/oel_6.7_apaas_16.4.5_1610211300" ]
   version        = 1
+}`, rInt)
 }
-`
 
 var testAccImageListEntry_Complete = `
 resource "opc_compute_image_list" "test" {

--- a/website/docs/r/opc_compute_image_list_entry.html.markdown
+++ b/website/docs/r/opc_compute_image_list_entry.html.markdown
@@ -51,8 +51,9 @@ In addition to the above arguments, the following attributes are exported
 
 ## Import
 
-Image List's can be imported using the `resource name`, e.g.
+Image List's can be imported using the Name of the Image List, along with the Version of the Image List Entry,
+delimited via the `|` character, e.g.
 
 ```shell
-$ terraform import opc_compute_image_list_entry.entry1 example
+$ terraform import opc_compute_image_list_entry.entry1 my_image_list|2
 ```


### PR DESCRIPTION
Fixes `opc_compute_image_list_entry` imports. Previously, importing
an image list entry would panic if the resource ID was not specified with
the correct delimiter `|`. This adds protection for the panic in two places,
once during the Read, and once during the Import function.

Also updates documentation for importing image list entry resources,
and adds an acceptance test for importing image list entries.

```
$ make testacc TEST=./opc TESTARGS="-run=TestAccOPCImageListEntry_importBasic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCImageListEntry_importBasic -timeout 120m
=== RUN   TestAccOPCImageListEntry_importBasic
--- PASS: TestAccOPCImageListEntry_importBasic (15.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-opc/opc       15.289s
```
Fixes: #26 