### PR TITLE
opc: Fix logging output

### DIFF
--- a/opc/config.go
+++ b/opc/config.go
@@ -110,5 +110,6 @@ func (l opcLogger) Log(args ...interface{}) {
 			tokens = append(tokens, token)
 		}
 	}
-	log.Printf("[DEBUG] [go-oracle-terraform]: %s", strings.Join(tokens, " "))
+	log.SetFlags(0)
+	log.Print(fmt.Sprintf("go-oracle-terraform: %s", strings.Join(tokens, " ")))
 }


### PR DESCRIPTION
Before:
```
2017/08/15 09:47:31 [DEBUG] plugin: terraform-provider-opc: 2017/08/15 09:47:31 [DEBUG] [go-oracle-terraform]: Waiting for storage volume /Compute-a459477/jake@hashicorp.com/boot-from-snapshot to become available (46/120s)
```

After:
```
2017/08/15 09:47:31 [DEBUG] plugin: terraform-provider-opc: go-oracle-terraform: Waiting for storage volume /Compute-a459477/jake@hashicorp.com/boot-from-snapshot to become available (46/120s)
```

Removes the duplicate timestamp and `[LOGLEVEL]` flags.