### PR TITLE
docs: Update docs for restoring volume from snapshot

### DIFF
--- a/website/docs/r/opc_compute_storage_volume.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume.html.markdown
@@ -52,9 +52,9 @@ The following arguments are supported:
 * `bootable` - (Optional) Is the Volume Bootable? Defaults to `false`.
 * `image_list` - (Optional) Defines an image list.
 * `image_list_entry` - (Optional) Defines an image list entry.
-* `snapshot` - (Optional) The name of the parent snapshot from which the storage volume is restored or cloned.
-* `snapshot_id` - (Optional) The Id of the parent snapshot from which the storage volume is restored or cloned.
-* `snapshot_account` - (Optional) The Account of the parent snapshot from which the storage volume is restored.
+* `snapshot` - (Optional) The name of the parent snapshot from which the storage volume is restored or cloned. See [Snapshots](#snapshots), below for more information.
+* `snapshot_id` - (Optional) The Id of the parent snapshot from which the storage volume is restored or cloned. See [Snapshots](#snapshots), below for more information.
+* `snapshot_account` - (Optional) The Account of the parent snapshot from which the storage volume is restored. See [Snapshots](#snapshots), below for more information.
 * `tags` - (Optional) Comma-separated strings that tag the storage volume.
 
 ## Attributes Reference
@@ -78,6 +78,42 @@ Storage Volume's can be imported using the `resource name`, e.g.
 $ terraform import opc_compute_storage_volume.volume1 example
 ```
 
+## Snapshots
+
+Restoring a storage volume from a snapshot can happen via the use of the `snapshot`, `snapshot_id`, and `snapshot_account` arguments.
+
+Note: There isn't a mechanism to restore a snapshot from a different domain, the `snapshot_account` argument needs to reference the same domain.
+
+There are two different ways to identify the snapshot in which to restore the storage volume:
+
+1. Use the unique `snapshot_id` argument.
+1. Use a combination of `snapshot_account` and `snapshot` arguments. `snapshot_account` is in the format of:
+`/Compute-mydomain/cloud_storage`, and `snapshot` is a concatenated name of the original storage volume name,
+and it's child snapshot name: `mystorage/mysnapshot`.
+
+Example 1:
+```hcl
+resource "opc_compute_storage_volume" "foo" {
+  name = "from-snapshot"
+  size = "10"
+  snapshot_account = "/Compute-${var.domain}/cloud_storage"
+  snapshot = "my-boot-volume/my-snapshot"
+}
+```
+
+Example 2:
+```hcl
+data "opc_compute_storage_volume_snapshot" "foo" {
+ name = "my-boot-volume/my-snapshot"
+}
+
+resource "opc_compute_storage_volume" "foo" {
+ name = "from-snapshot"
+ snapshot_id = "${opc_compute_storage_volume_snapshot.foo.snapshot_id}"
+ size = "${opc_compute_storage_volume_snapshot.foo.snapshot_id}"
+}
+```
+
 <a id="timeouts"></a>
 ## Timeouts
 
@@ -87,4 +123,3 @@ $ terraform import opc_compute_storage_volume.volume1 example
 - `create` - (Default `30 minutes`) Used for Creating Storage Volumes.
 - `update` - (Default `30 minutes`) Used for Modifying Storage Volumes.
 - `delete` - (Default `30 minutes`) Used for Deleting Storage Volumes.
-

--- a/website/docs/r/opc_compute_storage_volume.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume.html.markdown
@@ -80,9 +80,9 @@ $ terraform import opc_compute_storage_volume.volume1 example
 
 ## Snapshots
 
-Restoring a storage volume from a snapshot can happen via the use of the `snapshot`, `snapshot_id`, and `snapshot_account` arguments.
+Restoring a storage volume from a snapshot can happen via the use of the `snapshot`, `snapshot_id`, and `snapshot_account` attributes.
 
-Note: There isn't a mechanism to restore a snapshot from a different domain, the `snapshot_account` argument needs to reference the same domain.
+**Note**: There isn't a mechanism to restore a snapshot from a different domain, the `snapshot_account` argument needs to reference the same domain.
 
 There are two different ways to identify the snapshot in which to restore the storage volume:
 


### PR DESCRIPTION
Update documentation to clarify how to restore a storage volume from a
storage volume snapshot. This should help clarify the difference
between the three different snapshot arguments that are possible to
populate during a snapshot restoration.