### PR TITLE
r/ip_network: Allow changing the name of an IP Network

### DIFF
--- a/opc/resource_ip_network.go
+++ b/opc/resource_ip_network.go
@@ -22,6 +22,7 @@ func resourceOPCIPNetwork() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"ip_address_prefix": {

--- a/opc/resource_ip_network_test.go
+++ b/opc/resource_ip_network_test.go
@@ -68,6 +68,40 @@ func TestAccOPCIPNetwork_Update(t *testing.T) {
 	})
 }
 
+func TestAccOPCIPNetwork_UpdateName(t *testing.T) {
+	rInt := acctest.RandInt()
+	resName := "opc_compute_ip_network.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resName, testAccOPCCheckIPNetworkDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOPCIPNetworkConfig_Basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					opcResourceCheck(resName, testAccOPCCheckIPNetworkExists),
+					resource.TestCheckResourceAttr(resName, "ip_address_prefix", "10.0.12.0/24"),
+					resource.TestCheckResourceAttr(resName, "public_napt_enabled", "false"),
+					resource.TestCheckResourceAttr(resName, "description", fmt.Sprintf("testing-desc-%d", rInt)),
+					resource.TestCheckResourceAttr(resName, "name", fmt.Sprintf("testing-ip-network-%d", rInt)),
+					resource.TestMatchResourceAttr(resName, "uri", regexp.MustCompile("testing-ip-network")),
+				),
+			},
+			{
+				Config: testAccOPCIPNetworkConfig_BasicUpdateName(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					opcResourceCheck(resName, testAccOPCCheckIPNetworkExists),
+					resource.TestCheckResourceAttr(resName, "ip_address_prefix", "10.0.12.0/24"),
+					resource.TestCheckResourceAttr(resName, "public_napt_enabled", "true"),
+					resource.TestCheckResourceAttr(resName, "description", fmt.Sprintf("testing-desc-%d", rInt)),
+					resource.TestCheckResourceAttr(resName, "name", fmt.Sprintf("testing-new-ip-network-%d", rInt)),
+				),
+			},
+		},
+	})
+}
+
 func testAccOPCIPNetworkConfig_Basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "opc_compute_ip_network" "test" {
@@ -81,6 +115,16 @@ func testAccOPCIPNetworkConfig_BasicUpdate(rInt int) string {
 	return fmt.Sprintf(`
 resource "opc_compute_ip_network" "test" {
   name = "testing-ip-network-%d"
+  description = "testing-desc-%d"
+  ip_address_prefix = "10.0.12.0/24"
+  public_napt_enabled = true
+}`, rInt, rInt)
+}
+
+func testAccOPCIPNetworkConfig_BasicUpdateName(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_ip_network" "test" {
+  name = "testing-new-ip-network-%d"
   description = "testing-desc-%d"
   ip_address_prefix = "10.0.12.0/24"
   public_napt_enabled = true

--- a/website/docs/r/opc_compute_ip_network.html.markdown
+++ b/website/docs/r/opc_compute_ip_network.html.markdown
@@ -27,7 +27,7 @@ resource "opc_compute_ip_network" "foo" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the IP Network.
+* `name` - (Required) The name of the IP Network. Changing this name forces a new resource to be created.
 
 * `ip_address_prefix` - (Required) The IPv4 address prefix, in CIDR format.
 


### PR DESCRIPTION
Changing the Name of an IP Network is a `ForceNew` operation that would
previously fail to succeed, as the provider would make an API request to
the new `name` argument, which would subsequently fail. This change fixes
the behavior, by explicitly forcing a new resource to be created on a name
change.

```
$ make testacc TEST=./opc TESTARGS="-run=TestAccOPCIPNetwork_UpdateName"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCIPNetwork_UpdateName -timeout 120m
=== RUN   TestAccOPCIPNetwork_UpdateName
--- PASS: TestAccOPCIPNetwork_UpdateName (29.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-opc/opc       29.086s
```

Fixes: #71 