### PR TITLE
updating timeout for storage volume snapshots

### DIFF
--- a/opc/resource_storage_volume_snapshot.go
+++ b/opc/resource_storage_volume_snapshot.go
@@ -20,7 +20,7 @@ func resourceOPCStorageVolumeSnapshot() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/opc/resource_storage_volume_snapshot_test.go
+++ b/opc/resource_storage_volume_snapshot_test.go
@@ -31,6 +31,25 @@ func TestAccOPCStorageVolumeSnapshot_basic(t *testing.T) {
 	})
 }
 
+func TestAccOPCStorageVolumeSnapshot_bootableSnapshot(t *testing.T) {
+	snapshotName := "opc_compute_storage_volume_snapshot.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(snapshotName, testAccCheckStorageVolumeSnapshotDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageVolumeSnapshot_bootableSnapshot(rInt),
+				Check: resource.ComposeTestCheckFunc(opcResourceCheck(snapshotName, testAccCheckStorageVolumeSnapshotExists),
+					resource.TestCheckResourceAttr(snapshotName, "name", fmt.Sprintf("test-acc-stor-vol-snapshot-%d", rInt)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckStorageVolumeSnapshotExists(state *OPCResourceState) error {
 	client := state.ComputeClient.StorageVolumeSnapshots()
 	snapshotName := state.Attributes["name"]
@@ -85,4 +104,37 @@ resource "opc_compute_storage_volume_snapshot" "test" {
   volume_name = "${opc_compute_storage_volume.foo.name}"
 }
 `, rInt, rInt)
+}
+
+func testAccStorageVolumeSnapshot_bootableSnapshot(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_image_list" "test" {
+  name        = "test-acc-image-list-%d"
+  default     = 21
+  description = "description"
+}
+
+resource "opc_compute_image_list_entry" "test" {
+  name           = "${opc_compute_image_list.test.name}"
+  machine_images = [ "/oracle/public/oel_6.7_apaas_16.4.5_1610211300" ]
+  version        = 1
+}
+resource "opc_compute_storage_volume" "foo" {
+  name = "test-acc-stor-vol-%d"
+  description = "testAccStorageVolumeSnapshot_basic"
+  size = 50
+	tags        = ["bar", "foo"]
+	bootable = true
+  image_list = "${opc_compute_image_list.test.name}"
+  image_list_entry = "${opc_compute_image_list_entry.test.version}"
+}
+
+resource "opc_compute_storage_volume_snapshot" "test" {
+  name = "test-acc-stor-vol-snapshot-%d"
+  description = "storage volume snapshot"
+  collocated = true
+  volume_name = "${opc_compute_storage_volume.foo.name}"
+	parent_volume_bootable = true
+}
+`, rInt, rInt, rInt)
 }

--- a/vendor/github.com/hashicorp/go-oracle-terraform/client/client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/client/client.go
@@ -68,6 +68,7 @@ func NewClient(c *opc.Config) (*Client, error) {
 // After calling this you need to add the authentication. Header/Cookie/etc
 // Then call ExecuteRequest and pass in the return value of this method
 // It is split up to add additional authentication that is Oracle API dependent.
+// DEPRECATED
 func (c *Client) BuildRequest(method, path string, body interface{}) (*http.Request, error) {
 	// Parse URL Path
 	urlPath, err := url.Parse(path)
@@ -87,6 +88,42 @@ func (c *Client) BuildRequest(method, path string, body interface{}) (*http.Requ
 	}
 
 	// Create request
+	req, err := http.NewRequest(method, c.formatURL(urlPath), requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// Marshalls the request body and returns the resulting byte slice
+// This is split out of the BuildRequestBody method so as to allow
+// the developer to print a debug string of the request body if they
+// should so choose.
+func (c *Client) MarshallRequestBody(body interface{}) ([]byte, error) {
+	// Verify interface isnt' nil
+	if body == nil {
+		return nil, nil
+	}
+
+	return json.Marshal(body)
+}
+
+// Builds an HTTP Request that accepts a pre-marshaled body parameter as a raw byte array
+// Returns the raw HTTP Request and any error occured
+func (c *Client) BuildRequestBody(method, path string, body []byte) (*http.Request, error) {
+	// Parse URL Path
+	urlPath, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var requestBody io.ReadSeeker
+	if len(body) != 0 {
+		requestBody = bytes.NewReader(body)
+	}
+
+	// Create Request
 	req, err := http.NewRequest(method, c.formatURL(urlPath), requestBody)
 	if err != nil {
 		return nil, err
@@ -118,7 +155,7 @@ func (c *Client) ExecuteRequest(req *http.Request) (*http.Response, error) {
 	// Execute request with supplied client
 	resp, err := c.retryRequest(req)
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
@@ -138,7 +175,10 @@ func (c *Client) ExecuteRequest(req *http.Request) (*http.Response, error) {
 		oracleErr.Message = buf.String()
 	}
 
-	return nil, oracleErr
+	// Should return the response object regardless of error,
+	// some resources need to verify and check status code on errors to
+	// determine if an error actually occurs or not.
+	return resp, oracleErr
 }
 
 // Allow retrying the request until it either returns no error,
@@ -158,7 +198,7 @@ func (c *Client) retryRequest(req *http.Request) (*http.Response, error) {
 	for i := 0; i < retries; i++ {
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
-			return nil, err
+			return resp, err
 		}
 
 		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {

--- a/vendor/github.com/hashicorp/go-oracle-terraform/compute/compute_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/compute/compute_client.go
@@ -38,7 +38,12 @@ func NewComputeClient(c *opc.Config) (*ComputeClient, error) {
 }
 
 func (c *ComputeClient) executeRequest(method, path string, body interface{}) (*http.Response, error) {
-	req, err := c.client.BuildRequest(method, path, body)
+	reqBody, err := c.client.MarshallRequestBody(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.client.BuildRequestBody(method, path, reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -46,9 +51,9 @@ func (c *ComputeClient) executeRequest(method, path string, body interface{}) (*
 	debugReqString := fmt.Sprintf("HTTP %s Req (%s)", method, path)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/oracle-compute-v3+json")
-		// Don't leak creds in STDERR
+		// Don't leak credentials in STDERR
 		if path != "/authenticate/" {
-			debugReqString = fmt.Sprintf("%s:\n %+v", debugReqString, body)
+			debugReqString = fmt.Sprintf("%s:\n %+v", debugReqString, string(reqBody))
 		}
 	}
 	// Log the request before the authentication cookie, so as not to leak credentials

--- a/vendor/github.com/hashicorp/go-oracle-terraform/compute/storage_volume_snapshots.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/compute/storage_volume_snapshots.go
@@ -13,7 +13,7 @@ const (
 	StorageVolumeSnapshotContainerPath = "/storage/snapshot/"
 	StorageVolumeSnapshotResourcePath  = "/storage/snapshot"
 
-	WaitForSnapshotCreateTimeout = time.Duration(1200 * time.Second)
+	WaitForSnapshotCreateTimeout = time.Duration(2400 * time.Second)
 	WaitForSnapshotDeleteTimeout = time.Duration(1500 * time.Second)
 
 	// Collocated Snapshot Property

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/access_rules.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/access_rules.go
@@ -1,0 +1,291 @@
+// Manages Access Rules for a DBaaS Service Instance.
+// The only fields that can be Updated for an Access Rule is the desired state
+// of the access rule. From Enabled -> Disabled.
+// Deleting an Access Rule also requires an Update call, instead of a Delete API request,
+// but the Operation body parameter changes from `update` to `delete`.
+// All other parameters for the resource, aside from Status should be ForceNew.
+// The READ function for the AccessRule resource is tricky, as there is
+// no exposed `GET` function on the AccessRule API.
+// There is an API endpoint to view "all" rules, however, which will be used as a
+// data source to match on a supplied AccessRule name.
+// Timeout only supported for the CREATE method
+
+package database
+
+import "time"
+
+// API URI Paths for Container and Root objects
+const (
+	DBAccessContainerPath = "/paas/api/v1.1/instancemgmt/%s/services/dbaas/instances/%s/accessrules"
+	DBAccessRootPath      = "/paas/api/v1.1/instancemgmt/%s/services/dbaas/instances/%s/accessrules/%s"
+)
+
+// Default Timeout value for Create
+const WaitForAccessRuleTimeout = time.Duration(10 * time.Second)
+
+// AccessRules returns a UtilityClient for managing SSH Keys and Access Rules for a DBaaS Service Instance
+func (c *DatabaseClient) AccessRules() *UtilityClient {
+	return &UtilityClient{
+		UtilityResourceClient: UtilityResourceClient{
+			DatabaseClient:   c,
+			ContainerPath:    DBAccessContainerPath,
+			ResourceRootPath: DBAccessRootPath,
+		},
+	}
+}
+
+// Status Constants for an Access Rule
+type AccessRuleStatus string
+
+const (
+	AccessRuleEnabled  AccessRuleStatus = "enabled"
+	AccessRuleDisabled AccessRuleStatus = "disabled"
+)
+
+// Operational Constants for either Updating/Deleting an Access Rule
+type AccessRuleOperation string
+
+const (
+	AccessRuleUpdate AccessRuleOperation = "update"
+	AccessRuleDelete AccessRuleOperation = "delete"
+)
+
+// Default Destination for an Access Rule
+type AccessRuleDestination string
+
+const (
+	AccessRuleDefaultDestination AccessRuleDestination = "DB"
+)
+
+// Used for the GET request, as there's no direct GET request for a single Access Rule
+type AccessRules struct {
+	Rules []AccessRuleInfo `json:"accessRules"`
+}
+
+type AccessRuleType string
+
+const (
+	AccessRuleTypeDefault AccessRuleType = "DEFAULT"
+	AccessRuleTypeSystem  AccessRuleType = "SYSTEM"
+	AccessRuleTypeUser    AccessRuleType = "USER"
+)
+
+// AccessRuleInfo holds all of the known information for a single AccessRule
+type AccessRuleInfo struct {
+	// The Description of the Access Rule
+	Description string `json:"description"`
+	// The destination of the Access Rule. Should always be "DB".
+	Destination AccessRuleDestination `json:"destination"`
+	// The ports for the rule.
+	Ports string `json:"ports"`
+	// The name of the Access Rule
+	Name string `json:"ruleName"`
+	// The Type of the rule. One of: "DEFAULT", "SYSTEM", or "USER".
+	// Computed Value
+	RuleType AccessRuleType `json:"ruleType"`
+	// The IP Addresses and subnets from which traffic is allowed
+	Source string `json:"source"`
+	// The current status of the Access Rule
+	Status AccessRuleStatus `json:"status"`
+}
+
+// CreateAccessRuleInput defines the input parameters needed to create an Access Rule for a DBaaS Service Instance.
+type CreateAccessRuleInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Description of the Access Rule.
+	// Required
+	Description string `json:"description"`
+	// Destination to which traffic is allowed. Specify the value "DB".
+	// Required
+	Destination AccessRuleDestination `json:"destination"`
+	// The network port or ports to allow traffic on. Specified as a single port or a range.
+	// Required
+	Ports string `json:"ports"`
+	// The name of the Access Rule
+	// Required
+	Name string `json:"ruleName"`
+	// The IP addresses and subnets from which traffic is allowed.
+	// Valid values are:
+	//   - "DB" for any other cloud service instance in the service instances `ora_db` security list
+	//   - "PUBLIC-INTERNET" for any host on the internet.
+	//   - A single IP address or comma-separated list of subnets (in CIDR format) or IPv4 addresses.
+	// Required
+	Source string `json:"source"`
+	// Desired Status of the rule. Either "disabled" or "enabled".
+	// Required
+	Status AccessRuleStatus `json:"status"`
+	// Time to wait for an access rule to be ready
+	Timeout time.Duration `json:"-"`
+}
+
+// Creates an AccessRule with the supplied input struct.
+// The API call to Create returns a nil body object, and a 202 status code on success.
+// Thus, the Create method will return the resulting object from an internal GET call
+// during the WaitForReady timeout.
+func (c *UtilityClient) CreateAccessRule(input *CreateAccessRuleInput) (*AccessRuleInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	var accessRule AccessRuleInfo
+	if err := c.createResource(input, &accessRule); err != nil {
+		return nil, err
+	}
+
+	timeout := input.Timeout
+	if timeout == 0 {
+		timeout = WaitForAccessRuleTimeout
+	}
+
+	getInput := &GetAccessRuleInput{
+		Name: input.Name,
+	}
+
+	result, err := c.WaitForAccessRuleReady(getInput, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetAccessRuleInput defines the input parameters needed to retrieve information
+// on an AccessRule for a DBaas Service Instance.
+type GetAccessRuleInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Name of the Access Rule.
+	// Because there is no native "GET" to return a single AccessRuleInfo object, we don't
+	// need to marshal a request body for the GET request. Instead the request returns a slice
+	// of AccessRuleInfo structs, which we iterate on to interpret the desired AccessRuleInfo struct
+	// Required
+	Name string `json:"-"`
+}
+
+// Get's a slice of every AccessRule, and iterates on the result until
+// we find the correctly matching access rule. This is likely an expensive operation depending
+// on how many access rules the customer has. However, since there's no direct GET API endpoint
+// for a single Access Rule, it's not able to be optimized yet.
+func (c *UtilityClient) GetAccessRule(input *GetAccessRuleInput) (*AccessRuleInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	var accessRules AccessRules
+	if err := c.getResource("", &accessRules); err != nil {
+		return nil, err
+	}
+
+	// This is likely not the most optimal path for this, however, the upper bound on
+	// performance here is the actual API request, not the iteration.
+	for _, rule := range accessRules.Rules {
+		if rule.Name == input.Name {
+			return &rule, nil
+		}
+	}
+
+	// Iterated through entire slice, rule was not found.
+	// No error occured though, return a nil struct, and allow the Provdier to handle
+	// a Nil response case.
+	return nil, nil
+}
+
+// UpdateAccessRuleInput defines the Update parameters needed to update an AccessRule
+// for a DBaaS Service Instance.
+type UpdateAccessRuleInput struct {
+	// Name of the DBaaS Service Instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Name of the Access Rule. Used in the request's URI, not as a body parameter.
+	// Required
+	Name string `json:"-"`
+	// Type of Operation being performed. This should never be set in the Provider,
+	// as we're explicitly calling an Update function here, so the SDK uses the constant
+	// defined for Updating an AccessRule
+	// Do not set.
+	Operation AccessRuleOperation `json:"operation"`
+	// Desired Status of the Access Rule. This is the only attribute that can actually be
+	// modified on an access rule.
+	// Required
+	Status AccessRuleStatus `json:"status"`
+}
+
+// Updates an AccessRule with the provided input struct. Returns a fully populated Info struct
+// and any errors encountered
+func (c *UtilityClient) UpdateAccessRule(input *UpdateAccessRuleInput,
+) (*AccessRuleInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	// Since this is strictly an Update call, set the Operation constant
+	input.Operation = AccessRuleUpdate
+	// Initialize the response struct
+	var accessRule AccessRuleInfo
+	if err := c.updateResource(input.Name, input, &accessRule); err != nil {
+		return nil, err
+	}
+	return &accessRule, nil
+}
+
+// DeleteAccessRuleInput defines the Delete parameters needed to delete an AccessRule
+// for a DBaaS Service Instance. There's no dedicated DELETE method on the API, so this
+// mimics the same behavior of the Update method, but using the Delete operational constant.
+// Instead of implementing, choosing to be verbose here for ease of use in the Provider, and clarity.
+type DeleteAccessRuleInput struct {
+	// Name of the DBaaS Service Instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// Name of the Access Rule. Used in the request's URI, not as a body parameter.
+	// Required
+	Name string `json:"-"`
+	// Type of Operation being performed. This should never be set in the Provider,
+	// as we're explicitly calling an Delete function here, so the SDK uses the constant
+	// defined for Deleting an AccessRule
+	// Do not set.
+	Operation AccessRuleOperation `json:"operation"`
+	// Desired Status of the Access Rule. This is the only attribute that can actually be
+	// modified on an access rule.
+	// Required
+	Status AccessRuleStatus `json:"status"`
+}
+
+// Deletes an AccessRule with the provided input struct. Returns any errors that occurred.
+func (c *UtilityClient) DeleteAccessRule(input *DeleteAccessRuleInput) error {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	// Since this is strictly an Update call, set the Operation constant
+	input.Operation = AccessRuleDelete
+	// The Update API call with a `DELETE` operation actually returns the same access rule info
+	// in a response body. As we are deleting the AccessRule, we don't actually need to parse that.
+	// However, the Update API call requires a pointer to parse, or else we throw an error during the
+	// json unmarshal
+	var result AccessRuleInfo
+	if err := c.updateResource(input.Name, input, &result); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *UtilityClient) WaitForAccessRuleReady(input *GetAccessRuleInput, timeout time.Duration) (*AccessRuleInfo, error) {
+	var info *AccessRuleInfo
+	var getErr error
+	err := c.client.WaitFor("access rule to be ready", timeout, func() (bool, error) {
+		info, getErr = c.GetAccessRule(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		if info != nil {
+			// Rule found, return. Desired case
+			return true, nil
+		}
+		// Rule not found, wait
+		return false, nil
+	})
+	return info, err
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/ssh_keys.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/ssh_keys.go
@@ -1,0 +1,170 @@
+// Manages SSH Keys for a DBaaS Service Instance.
+// SSH Keys can currently only be created and information fetched. They cannot
+// be updated, or deleted via the API. So each interaction requires a ForceNew
+// and "deleting" the resource simply removes the resource from state
+// (in the provider), as there is no Delete method on the ssh key resource's
+// API.
+
+package database
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// API URI Paths for Container and Root objects.
+// API Docs state to always set the 'credentialName' attribute in the
+// resource's path to 'vmspublickey'. Hard-coding for now, but a better solution
+// may need to be solved for SSH Keys if this value ever needs to be changed.
+// See: https://docs.oracle.com/en/cloud/paas/database-dbaas-cloud/csdbr/op-paas-api-v1.1-instancemgmt-%7BidentityDomainId%7D-services-dbaas-instances-%7BserviceId%7D-credentials-crednames-%7BcredentialName%7D-post.html
+// for more details on 'credentialName'.
+
+// The Root Path, for SSH Keys also does not expect a conventional 'Name'
+// path parameter, and the only difference between creating an SSH Key
+// and viewing the summary of the current SSH Key is a PUT vs GET HTTP Method.
+const (
+	DBSSHKeyContainerPath = "/paas/api/v1.1/instancemgmt/%s/services/dbaas/instances/%s/credentials/crednames/vmspublickey"
+	DBSSHKeyRootPath      = "/paas/api/v1.1/instancemgmt/%s/services/dbaas/instances/%s/credentials/%s"
+	DBSSHKeyName          = "vmspublickey"
+)
+
+// Default timeout value for Create
+// In testing this is anywhere between 10-20s depending on if it's a new SSH Key
+// or if it's an "updated" ssh key.
+const WaitForSSHKeyTimeout = time.Duration(30 * time.Second)
+
+// SSHKeys returns a UtilityClient for managing SSHKeys for a DBaaS Service Instance
+func (c *DatabaseClient) SSHKeys() *UtilityClient {
+	return &UtilityClient{
+		UtilityResourceClient: UtilityResourceClient{
+			DatabaseClient:   c,
+			ContainerPath:    DBSSHKeyContainerPath,
+			ResourceRootPath: DBSSHKeyRootPath,
+		},
+	}
+}
+
+// SSHKeyInfo holds all the known information for a single SSH Key
+type SSHKeyInfo struct {
+	// This will likely always be "DB".
+	ComponentType string `json:"componentType"`
+	// The fully qualified name of the SSH Key object in OPC Cloud Storage
+	// where the SSH public key value is stored.
+	ComputeKeyName string `json:"computeKeyName"`
+	// Should always be 'vmspublickey'
+	CredName string `json:"credName"`
+	// Should always be SSH
+	CredType string `json:"credType"`
+	// The string description of the key
+	Description string `json:"description"`
+	// Note: The API supplies us with the 'identityDomain' key here,
+	// but since we are required to supply this during the API request
+	// and it's already a "known" value, we don't return the value here as well.
+
+	// The message returned from the last update of the SSH Key.
+	LastUpdateMessage string `json:"lastUpdateMessage"`
+	// Status of the last update of the SSH key
+	LastUpdateStatus string `json:"lastUpdateStatus"`
+	// Date and time of the last update of the SSH Key
+	LastUpdateTime string `json:"lastUpdateTime"`
+	// The value "opc"
+	OsUserName string `json:"osUserName"`
+	// The value "SERVICE"
+	ParentType string `json:"parentType"`
+	// The Value of the SSH Public Key with any slashes (/) it contains
+	// preceded by backslashes: \/.
+	PublicKey string `json:"publicKey"`
+	// The name of the DatabaseCloudService Instance
+	ServiceName string `json:"serviceName"`
+	// The value "DBaaS"
+	ServiceType string `json:"serviceType"`
+}
+
+// CreateSSHKeyInput defines the necessary input parameters to create an
+// SSH Key for a DBaaS Service Instance
+type CreateSSHKeyInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+	// The value of the SSH public key, with any slashes (/) it contains preceded by
+	// backslashes, as in \/.
+	// Required
+	PublicKey string `json:"public-key"`
+	// Time to wait for an ssh key to be ready
+	Timeout time.Duration `json:"-"`
+}
+
+// Creates an SSH Key with the supplied input struct.
+func (c *UtilityClient) CreateSSHKey(input *CreateSSHKeyInput) (*SSHKeyInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	var sshKey SSHKeyInfo
+	if err := c.createResource(input, &sshKey); err != nil {
+		return nil, err
+	}
+
+	timeout := input.Timeout
+	if timeout == 0 {
+		timeout = WaitForSSHKeyTimeout
+	}
+
+	// Can leave ServiceInstanceID nil here, it will be the same as the current client's
+	result, err := c.WaitForSSHKeyReady(&GetSSHKeyInput{}, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetSSHKeyInput defines all of the necessary input parameters to retrieve the necessary
+// information on a specific SSH Key.
+type GetSSHKeyInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+}
+
+// Get's information on a single SSH Key
+func (c *UtilityClient) GetSSHKey(input *GetSSHKeyInput) (*SSHKeyInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+
+	// Name has to be populated in this case as the Container path and the Root path are completely
+	// separate paths. Otherwise, with a nil name, the Container path would have been used, which
+	// would effectively return a '200 OK' for each request, but only return the summary for an SSH Key
+	// instead of details
+	var sshKey SSHKeyInfo
+	if err := c.getResource(DBSSHKeyName, &sshKey); err != nil {
+		return nil, err
+	}
+
+	return &sshKey, nil
+}
+
+// No Delete, or Update currently.
+// TODO: Add Delete and Update for SSH Keys when they are available in the API.
+
+func (c *UtilityClient) WaitForSSHKeyReady(input *GetSSHKeyInput, timeout time.Duration) (*SSHKeyInfo, error) {
+	var info *SSHKeyInfo
+	var getErr error
+	err := c.client.WaitFor("sshkey to be ready", timeout, func() (bool, error) {
+		info, getErr = c.GetSSHKey(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		if info != nil {
+			c.client.DebugLogString(fmt.Sprintf("SSH Key Status: %s", strings.ToLower(info.LastUpdateStatus)))
+			success := strings.ToLower(info.LastUpdateStatus) == "success"
+			return success, nil
+		}
+		// Not found, wait
+		c.client.DebugLogString(fmt.Sprintf("SSH Key not found, waiting"))
+		return false, nil
+	})
+	return info, err
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/utility_resource_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/utility_resource_client.go
@@ -1,0 +1,115 @@
+package database
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// The UtilityClient which extends the UtilityResourceClient.
+// This is purely because utility resources (SSH Keys + Access Rules) include the service
+// instance name in the URL path for managing these resources, so we cannot use the same
+// resource client that the service instance uses. We're still using the same OPC client, just
+// abstracting the path helper functions to make life a little easier.
+type UtilityClient struct {
+	UtilityResourceClient
+}
+
+// UtilityResourceClient is a client to manage resources on an already created service instance
+type UtilityResourceClient struct {
+	*DatabaseClient
+	ContainerPath     string
+	ResourceRootPath  string
+	ServiceInstanceID string
+}
+
+func (c *UtilityResourceClient) createResource(requestBody interface{}, responseBody interface{}) error {
+	_, err := c.executeRequest("POST", c.getContainerPath(c.ContainerPath), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *UtilityResourceClient) updateResource(name string, requestBody interface{}, responseBody interface{}) error {
+	resp, err := c.executeRequest("PUT", c.getObjectPath(c.ResourceRootPath, name), requestBody)
+	if err != nil {
+		return err
+	}
+
+	return c.unmarshalResponseBody(resp, responseBody)
+}
+
+func (c *UtilityResourceClient) getResource(name string, responseBody interface{}) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.getContainerPath(c.ContainerPath)
+	}
+
+	resp, err := c.executeRequest("GET", objectPath, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.unmarshalResponseBody(resp, responseBody)
+}
+
+func (c *UtilityResourceClient) deleteResource(name string, body interface{}) error {
+	var objectPath string
+	if name != "" {
+		objectPath = c.getObjectPath(c.ResourceRootPath, name)
+	} else {
+		objectPath = c.ResourceRootPath
+	}
+	_, err := c.executeRequest("DELETE", objectPath, body)
+	if err != nil {
+		return err
+	}
+
+	// No errors and no response body to write
+	return nil
+}
+
+func (c *UtilityResourceClient) unmarshalResponseBody(resp *http.Response, iface interface{}) error {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	c.client.DebugLogString(fmt.Sprintf("HTTP Resp (%d): %s", resp.StatusCode, buf.String()))
+	// JSON decode response into interface
+	var tmp interface{}
+	dcd := json.NewDecoder(buf)
+	if err := dcd.Decode(&tmp); err != nil {
+		return fmt.Errorf("%+v", resp)
+		return err
+	}
+
+	// Use mapstructure to weakly decode into the resulting interface
+	msdcd, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           iface,
+		TagName:          "json",
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := msdcd.Decode(tmp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *UtilityResourceClient) getContainerPath(root string) string {
+	// /paas/api/v1.1/instancemgmt/{identityDomainId}/services/dbaas/instances/{serviceId}/accessrules
+	return fmt.Sprintf(root, *c.client.IdentityDomain, c.ServiceInstanceID)
+}
+
+func (c *UtilityResourceClient) getObjectPath(root, name string) string {
+	// /paas/api/v1.1/instancemgmt/{identityDomainId}/services/dbaas/instances/{serviceId}/accessrules/{ruleName}
+	return fmt.Sprintf(root, *c.client.IdentityDomain, c.ServiceInstanceID, name)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -254,44 +254,44 @@
 			"revision": "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
 		},
 		{
-			"checksumSHA1": "8N/9z3bEh+6LqR9Yfe1+FcjJZDs=",
+			"checksumSHA1": "hc/EkPH26GzST0jazlZk0rOsty4=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "e776bbde874a5e9e7b076727e3e60a9c54fd8034",
-			"revisionTime": "2017-08-16T13:31:45Z",
-			"version": "v0.3.4",
-			"versionExact": "v0.3.4"
+			"revision": "d1b0e9affb138d06c32c582d4882ffbfc6497ea2",
+			"revisionTime": "2017-09-14T16:37:18Z",
+			"version": "=v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
-			"checksumSHA1": "tGFXorLfoFylYNJZ9hTP31S7TBA=",
+			"checksumSHA1": "L6NeEU8piRVKbSuzd7U7mYDFUgo=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "e776bbde874a5e9e7b076727e3e60a9c54fd8034",
-			"revisionTime": "2017-08-16T13:31:45Z",
-			"version": "v0.3.4",
-			"versionExact": "v0.3.4"
+			"revision": "d1b0e9affb138d06c32c582d4882ffbfc6497ea2",
+			"revisionTime": "2017-09-14T16:37:18Z",
+			"version": "=v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
-			"checksumSHA1": "PhmW3m7d3kwkT2WjndZiFr1UtNU=",
+			"checksumSHA1": "E7dGmtLqjJnfc+Wz3paDimFVI8I=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "e776bbde874a5e9e7b076727e3e60a9c54fd8034",
-			"revisionTime": "2017-08-16T13:31:45Z",
-			"version": "v0.3.4",
-			"versionExact": "v0.3.4"
+			"revision": "d1b0e9affb138d06c32c582d4882ffbfc6497ea2",
+			"revisionTime": "2017-09-14T16:37:18Z",
+			"version": "=v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "JbuYtbJkx3r1BLuCMymkri0Q1BI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "e776bbde874a5e9e7b076727e3e60a9c54fd8034",
-			"revisionTime": "2017-08-16T13:31:45Z",
-			"version": "v0.3.4",
-			"versionExact": "v0.3.4"
+			"revision": "d1b0e9affb138d06c32c582d4882ffbfc6497ea2",
+			"revisionTime": "2017-09-14T16:37:18Z",
+			"version": "=v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "H8V9Z6p2ezWTQmDkKrcnlIYg8q4=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "e776bbde874a5e9e7b076727e3e60a9c54fd8034",
-			"revisionTime": "2017-08-16T13:31:45Z",
-			"version": "v0.3.4",
-			"versionExact": "v0.3.4"
+			"revision": "d1b0e9affb138d06c32c582d4882ffbfc6497ea2",
+			"revisionTime": "2017-09-14T16:37:18Z",
+			"version": "=v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",


### PR DESCRIPTION
Updating snapshot volume timeout and adding large snapshots to test. 

```
make testacc TEST=./opc TESTARGS="-run=TestAccOPCStorageVolume"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCStorageVolume -timeout 120m
=== RUN   TestAccOPCStorageVolumeSnapshot_importBasic
--- PASS: TestAccOPCStorageVolumeSnapshot_importBasic (40.12s)
=== RUN   TestAccOPCStorageVolume_importBasic
--- PASS: TestAccOPCStorageVolume_importBasic (29.22s)
=== RUN   TestAccOPCStorageVolume_importComplete
--- PASS: TestAccOPCStorageVolume_importComplete (30.47s)
=== RUN   TestAccOPCStorageVolume_importMaxSize
--- PASS: TestAccOPCStorageVolume_importMaxSize (25.34s)
=== RUN   TestAccOPCStorageVolume_importBootable
--- PASS: TestAccOPCStorageVolume_importBootable (45.79s)
=== RUN   TestAccOPCStorageVolume_importImageListEntry
--- PASS: TestAccOPCStorageVolume_importImageListEntry (37.00s)
=== RUN   TestAccOPCStorageVolume_importLowLatency
--- PASS: TestAccOPCStorageVolume_importLowLatency (31.18s)
=== RUN   TestAccOPCStorageVolume_importFromSnapshot
--- PASS: TestAccOPCStorageVolume_importFromSnapshot (51.12s)
=== RUN   TestAccOPCStorageVolumeSnapshot_basic
--- PASS: TestAccOPCStorageVolumeSnapshot_basic (39.22s)
=== RUN   TestAccOPCStorageVolumeSnapshot_bootableSnapshot
--- PASS: TestAccOPCStorageVolumeSnapshot_bootableSnapshot (51.18s)
=== RUN   TestAccOPCStorageVolume_Basic
--- PASS: TestAccOPCStorageVolume_Basic (26.94s)
=== RUN   TestAccOPCStorageVolume_Complete
--- PASS: TestAccOPCStorageVolume_Complete (25.36s)
=== RUN   TestAccOPCStorageVolume_MaxSize
--- PASS: TestAccOPCStorageVolume_MaxSize (28.68s)
=== RUN   TestAccOPCStorageVolume_Update
--- PASS: TestAccOPCStorageVolume_Update (45.73s)
=== RUN   TestAccOPCStorageVolume_Bootable
--- PASS: TestAccOPCStorageVolume_Bootable (38.90s)
=== RUN   TestAccOPCStorageVolume_BootableEndToEnd
--- PASS: TestAccOPCStorageVolume_BootableEndToEnd (563.72s)
=== RUN   TestAccOPCStorageVolume_FromBootableSnapshot
--- PASS: TestAccOPCStorageVolume_FromBootableSnapshot (2665.56s)
=== RUN   TestAccOPCStorageVolume_ImageListEntry
--- PASS: TestAccOPCStorageVolume_ImageListEntry (40.14s)
=== RUN   TestAccOPCStorageVolume_LowLatency
--- PASS: TestAccOPCStorageVolume_LowLatency (30.56s)
=== RUN   TestAccOPCStorageVolume_FromSnapshot
--- PASS: TestAccOPCStorageVolume_FromSnapshot (54.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opc/opc	3901.132s
```