### PR TITLE
Removing validation around storage_type

### DIFF
--- a/opc/resource_storage_volume.go
+++ b/opc/resource_storage_volume.go
@@ -47,10 +47,6 @@ func resourceOPCStorageVolume() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Default:  compute.StorageVolumeKindDefault,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.StorageVolumeKindDefault),
-					string(compute.StorageVolumeKindLatency),
-				}, true),
 			},
 
 			"snapshot": {

--- a/website/docs/r/opc_compute_storage_volume.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `name` (Required) The name for the Storage Account.
 * `description` (Optional) The description of the storage volume.
 * `size` (Required) The size of this storage volume in GB. The allowed range is from 1 GB to 2 TB (2048 GB).
-* `storage_type` - (Optional) - The Type of Storage to provision. Possible values are `/oracle/public/storage/latency` or `/oracle/public/storage/default`. Defaults to `/oracle/public/storage/default`.
+* `storage_type` - (Optional) - The Type of Storage to provision. Defaults to `/oracle/public/storage/default`.
 * `bootable` - (Optional) Is the Volume Bootable? Defaults to `false`.
 * `image_list` - (Optional) Defines an image list.
 * `image_list_entry` - (Optional) Defines an image list entry.


### PR DESCRIPTION
Oracle has suggested removing the validation around storage_types because they are locked by region and could release more. Fixes #37 

```
make testacc TEST=./opc TESTARGS="-run=TestAccOPCStorageVolume_Basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCStorageVolume_Basic -timeout 120m
=== RUN   TestAccOPCStorageVolume_Basic
--- PASS: TestAccOPCStorageVolume_Basic (46.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opc/opc	46.461s
```