### PR TITLE
Adding db service instance back into opc

### DIFF
--- a/opc/import_database_service_instance_test.go
+++ b/opc/import_database_service_instance_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestAccOPCDatabaseServiceInstance_importBasic(t *testing.T) {
-	t.Skip("Skipping test until we release this resource")
-
 	resourceName := "opc_database_service_instance.test"
 
 	ri := acctest.RandInt()

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -100,8 +100,7 @@ func Provider() terraform.ResourceProvider {
 			"opc_compute_snapshot":                resourceOPCSnapshot(),
 			"opc_storage_container":               resourceOPCStorageContainer(),
 			"opc_storage_object":                  resourceOPCStorageObject(),
-			// Unable to test
-			// "opc_database_service_instance":       resourceOPCDatabaseServiceInstance(),
+			"opc_database_service_instance":       resourceOPCDatabaseServiceInstance(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/opc/provider_test.go
+++ b/opc/provider_test.go
@@ -32,23 +32,21 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	// TODO: Add OPC_DATABASE_ENDPOINT when we release service instance
-	required := []string{"OPC_USERNAME", "OPC_PASSWORD", "OPC_IDENTITY_DOMAIN", "OPC_ENDPOINT", "OPC_STORAGE_ENDPOINT"}
+	required := []string{"OPC_USERNAME", "OPC_PASSWORD", "OPC_IDENTITY_DOMAIN", "OPC_ENDPOINT", "OPC_STORAGE_ENDPOINT", "OPC_DATABASE_ENDPOINT"}
 	for _, prop := range required {
 		if os.Getenv(prop) == "" {
 			t.Fatalf("%s must be set for acceptance test", prop)
 		}
 	}
 	config := Config{
-		User:            os.Getenv("OPC_USERNAME"),
-		Password:        os.Getenv("OPC_PASSWORD"),
-		IdentityDomain:  os.Getenv("OPC_IDENTITY_DOMAIN"),
-		Endpoint:        os.Getenv("OPC_ENDPOINT"),
-		MaxRetries:      1,
-		Insecure:        false,
-		StorageEndpoint: os.Getenv("OPC_STORAGE_ENDPOINT"),
-		// TODO Remove comment once we add database service instance back
-		// DatabaseEndpoint: os.Getenv("OPC_DATABASE_ENDPOINT"),
+		User:             os.Getenv("OPC_USERNAME"),
+		Password:         os.Getenv("OPC_PASSWORD"),
+		IdentityDomain:   os.Getenv("OPC_IDENTITY_DOMAIN"),
+		Endpoint:         os.Getenv("OPC_ENDPOINT"),
+		MaxRetries:       1,
+		Insecure:         false,
+		StorageEndpoint:  os.Getenv("OPC_STORAGE_ENDPOINT"),
+		DatabaseEndpoint: os.Getenv("OPC_DATABASE_ENDPOINT"),
 	}
 	client, err := config.Client()
 	if err != nil {

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -2,6 +2,7 @@ package opc
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/go-oracle-terraform/database"
@@ -11,7 +12,6 @@ import (
 )
 
 func TestAccOPCDatabaseServiceInstance_Basic(t *testing.T) {
-	t.Skip("Skipping test until we release this resource")
 	ri := acctest.RandInt()
 	config := testAccDatabaseServiceInstanceBasic(ri)
 	resourceName := "opc_database_service_instance.test"
@@ -39,7 +39,6 @@ func TestAccOPCDatabaseServiceInstance_Basic(t *testing.T) {
 }
 
 func TestAccOPCDatabaseServiceInstance_CloudStorage(t *testing.T) {
-	t.Skip("Skipping test until we release this resource")
 	ri := acctest.RandInt()
 	config := testAccDatabaseServiceInstanceCloudStorage(ri)
 	resourceName := "opc_database_service_instance.test"
@@ -53,7 +52,7 @@ func TestAccOPCDatabaseServiceInstance_CloudStorage(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseServiceInstanceExists,
 					resource.TestCheckResourceAttr(
-						resourceName, "cloud_storage_container", fmt.Sprintf("Storage-canonical/matthew-test-%d", ri)),
+						resourceName, "cloud_storage_container", fmt.Sprintf("Storage-%s/matthew-test-%d", os.Getenv("OPC_IDENTITY_DOMAIN"), ri)),
 				),
 			},
 		},
@@ -138,8 +137,8 @@ func testAccDatabaseServiceInstanceCloudStorage(rInt int) string {
       usable_storage = 15
     }
     cloud_storage {
-      container = "Storage-canonical/matthew-test-%d"
+      container = "Storage-%s/matthew-test-%d"
       create_if_missing = true
     }
-	}`, rInt, rInt)
+	}`, rInt, os.Getenv("OPC_IDENTITY_DOMAIN"), rInt)
 }

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -52,7 +52,7 @@ func TestAccOPCDatabaseServiceInstance_CloudStorage(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseServiceInstanceExists,
 					resource.TestCheckResourceAttr(
-						resourceName, "cloud_storage_container", fmt.Sprintf("Storage-%s/matthew-test-%d", os.Getenv("OPC_IDENTITY_DOMAIN"), ri)),
+						resourceName, "cloud_storage_container", fmt.Sprintf("Storage-%s/acctest-%d", os.Getenv("OPC_IDENTITY_DOMAIN"), ri)),
 				),
 			},
 		},
@@ -137,7 +137,7 @@ func testAccDatabaseServiceInstanceCloudStorage(rInt int) string {
       usable_storage = 15
     }
     cloud_storage {
-      container = "Storage-%s/matthew-test-%d"
+      container = "Storage-%s/acctest-%d"
       create_if_missing = true
     }
 	}`, rInt, os.Getenv("OPC_IDENTITY_DOMAIN"), rInt)


### PR DESCRIPTION
This PR is adding service db back into the provider now that we have our own testing account. 

```
make testacc TEST=./opc TESTARGS="-run=TestAccOPCDatabaseServiceInstance"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCDatabaseServiceInstance -timeout 300m
=== RUN   TestAccOPCDatabaseServiceInstance_importBasic
--- PASS: TestAccOPCDatabaseServiceInstance_importBasic (2456.35s)
=== RUN   TestAccOPCDatabaseServiceInstance_Basic
--- PASS: TestAccOPCDatabaseServiceInstance_Basic (2440.85s)
=== RUN   TestAccOPCDatabaseServiceInstance_CloudStorage
--- PASS: TestAccOPCDatabaseServiceInstance_CloudStorage (3009.50s)
PASS
```