### PR TITLE
add is_default_gateway attribute

### DIFF
--- a/opc/resource_instance.go
+++ b/opc/resource_instance.go
@@ -136,6 +136,13 @@ func resourceInstance() *schema.Resource {
 							Optional: true,
 						},
 
+						"is_default_gateway": {
+							// Optional, IP Network only
+							Type: 	  schema.TypeBool,
+							ForceNew: true,
+							Optional: true,
+						},
+
 						"mac_address": {
 							// Optional, IP Network Only
 							Type:     schema.TypeString,
@@ -769,6 +776,7 @@ func validateSharedNetwork(ni map[string]interface{}) error {
 	// The following attributes _cannot_ be set for a shared network:
 	// - "ip_address"
 	// - "ip_network"
+	// - "is_default_gateway"
 	// - "mac_address"
 	// - "vnic"
 	// - "vnic_sets"
@@ -781,6 +789,7 @@ func validateSharedNetwork(ni map[string]interface{}) error {
 	nilAttrs := []string{
 		"ip_address",
 		"ip_network",
+		"is_default_gateway",
 		"mac_address",
 		"vnic",
 	}
@@ -821,6 +830,10 @@ func readIPNetworkFromConfig(ni map[string]interface{}) (compute.NetworkingInfo,
 
 	if v, ok := ni["ip_address"].(string); ok && v != "" {
 		info.IPAddress = v
+	}
+
+	if v, ok := ni["is_default_gateway"].(bool); ok {
+		info.IsDefaultGateway = v
 	}
 
 	if v, ok := ni["mac_address"].(string); ok && v != "" {
@@ -908,6 +921,7 @@ func readNetworkInterfaces(d *schema.ResourceData, ifaces map[string]compute.Net
 			return err
 		}
 		res["index"] = indexInt
+		res["is_default_gateway"] = iface.IsDefaultGateway
 
 		// Set the proper attributes for this specific network interface
 		if iface.DNS != nil {

--- a/opc/resource_instance_test.go
+++ b/opc/resource_instance_test.go
@@ -110,6 +110,7 @@ func TestAccOPCInstance_ipNetwork(t *testing.T) {
 					resource.TestCheckResourceAttr(dataName, "ip_network", fmt.Sprintf("testing-ip-network-%d", rInt)),
 					resource.TestCheckResourceAttr(dataName, "vnic", fmt.Sprintf("ip-network-test-%d", rInt)),
 					resource.TestCheckResourceAttr(dataName, "shared_network", "false"),
+					resource.TestCheckResourceAttr(dataName, "is_default_gateway", "true"),
 				),
 			},
 		},
@@ -336,6 +337,7 @@ resource "opc_compute_instance" "test" {
     ip_network = "${opc_compute_ip_network.foo.id}"
     vnic = "ip-network-test-%d"
     shared_network = false
+		is_default_gateway = true
   }
 }
 

--- a/vendor/github.com/hashicorp/go-oracle-terraform/compute/instances.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/compute/instances.go
@@ -254,6 +254,10 @@ type NetworkingInfo struct {
 	// IP Network only.
 	// The hexadecimal MAC Address of the interface
 	// Optional
+	IsDefaultGateway bool `json:"is_default_gateway,omitempty"`
+	// IP Network only.
+	// Set interface as default gateway for all traffic
+	// Optional
 	MACAddress string `json:"address,omitempty"`
 	// Shared Network only.
 	// The type of NIC used. Must be set to 'e1000'

--- a/website/docs/r/opc_compute_instance.html.markdown
+++ b/website/docs/r/opc_compute_instance.html.markdown
@@ -131,6 +131,7 @@ The following attributes are supported:
 * `dns` - (Optional) Array of DNS servers for the interface.
 * `ip_address` - (Optional, IP Network Only) IP Address assigned to the interface.
 * `ip_network` - (Optional, IP Network Only) The IP Network assigned to the interface.
+* `is_default_gateway` - (Optional, IP Network Only) Specify the interface is to be used as the default gateway for all traffic. Only one interface on an instance can be specified as the default gateway. If the instance has an interface on the shared network, that interface is always used as the default gateway.
 * `mac_address` - (Optional, IP Network Only) The MAC address of the interface.
 * `model` - (Required, Shared Network Only) The model of the NIC card used. Must be set to `e1000`.
 * `name_servers` - (Optional) Array of name servers for the interface.


### PR DESCRIPTION
Add support for the `is_default_gateway` attribute in the compute instance `networking_info` block used to designate the default gateway interface for IP Network interfaces

Fixes #64 