### PR TITLE
Adding default gateway value to resource/data source

### DIFF
--- a/opc/data_source_network_interface.go
+++ b/opc/data_source_network_interface.go
@@ -46,6 +46,11 @@ func dataSourceNetworkInterface() *schema.Resource {
 				Computed: true,
 			},
 
+			"is_default_gateway": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"mac_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -151,6 +156,7 @@ func dataSourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("ip_address", result.IPAddress)
 	d.Set("ip_network", result.IPNetwork)
 	d.Set("mac_address", result.MACAddress)
+	d.Set("is_default_gateway", result.IsDefaultGateway)
 	d.Set("model", result.Model)
 	d.Set("vnic", result.Vnic)
 

--- a/opc/resource_instance.go
+++ b/opc/resource_instance.go
@@ -136,6 +136,13 @@ func resourceInstance() *schema.Resource {
 							Optional: true,
 						},
 
+						"is_default_gateway": {
+							// Optional, IP Network only
+							Type:     schema.TypeBool,
+							ForceNew: true,
+							Optional: true,
+						},
+
 						"mac_address": {
 							// Optional, IP Network Only
 							Type:     schema.TypeString,
@@ -769,6 +776,7 @@ func validateSharedNetwork(ni map[string]interface{}) error {
 	// The following attributes _cannot_ be set for a shared network:
 	// - "ip_address"
 	// - "ip_network"
+	// - "is_default_gateway"
 	// - "mac_address"
 	// - "vnic"
 	// - "vnic_sets"
@@ -781,6 +789,7 @@ func validateSharedNetwork(ni map[string]interface{}) error {
 	nilAttrs := []string{
 		"ip_address",
 		"ip_network",
+		"is_default_gateway",
 		"mac_address",
 		"vnic",
 	}
@@ -821,6 +830,10 @@ func readIPNetworkFromConfig(ni map[string]interface{}) (compute.NetworkingInfo,
 
 	if v, ok := ni["ip_address"].(string); ok && v != "" {
 		info.IPAddress = v
+	}
+
+	if v, ok := ni["is_default_gateway"].(bool); ok {
+		info.IsDefaultGateway = v
 	}
 
 	if v, ok := ni["mac_address"].(string); ok && v != "" {
@@ -908,6 +921,7 @@ func readNetworkInterfaces(d *schema.ResourceData, ifaces map[string]compute.Net
 			return err
 		}
 		res["index"] = indexInt
+		res["is_default_gateway"] = iface.IsDefaultGateway
 
 		// Set the proper attributes for this specific network interface
 		if iface.DNS != nil {

--- a/opc/resource_instance_test.go
+++ b/opc/resource_instance_test.go
@@ -116,6 +116,47 @@ func TestAccOPCInstance_ipNetwork(t *testing.T) {
 	})
 }
 
+func TestAccOPCInstance_ipNetworkIsDefaultGateway(t *testing.T) {
+	rInt := acctest.RandInt()
+	resName := "opc_compute_instance.test"
+	dataName := "data.opc_compute_network_interface.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOPCCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceIPNetworkingDefaultGateway(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccOPCCheckInstanceExists,
+					resource.TestCheckResourceAttrSet(resName, "id"),
+					resource.TestCheckResourceAttrSet(resName, "availability_domain"),
+					resource.TestCheckResourceAttrSet(resName, "domain"),
+					resource.TestCheckResourceAttrSet(resName, "ip_address"),
+					resource.TestCheckResourceAttr(resName, "name", fmt.Sprintf("acc-test-instance-%d", rInt)),
+					resource.TestCheckResourceAttr(resName, "networking_info.#", "1"),
+					// Default Placement Reqs
+					resource.TestCheckResourceAttr(resName, "placement_requirements.#", "2"),
+					resource.TestCheckResourceAttr(resName, "placement_requirements.0", "/system/compute/allow_instances"),
+					resource.TestCheckResourceAttr(resName, "placement_requirements.1", "/system/compute/placement/default"),
+					resource.TestCheckResourceAttr(resName, "platform", "linux"),
+					resource.TestCheckResourceAttr(resName, "priority", "/oracle/public/default"),
+					resource.TestCheckResourceAttr(resName, "reverse_dns", "true"),
+					resource.TestCheckResourceAttr(resName, "state", "running"),
+					resource.TestCheckResourceAttr(resName, "virtio", "false"),
+
+					// Check Data Source to validate networking attributes
+					resource.TestCheckResourceAttr(dataName, "ip_network", fmt.Sprintf("testing-ip-network-%d", rInt)),
+					resource.TestCheckResourceAttr(dataName, "vnic", fmt.Sprintf("ip-network-test-%d", rInt)),
+					resource.TestCheckResourceAttr(dataName, "shared_network", "false"),
+					resource.TestCheckResourceAttr(dataName, "is_default_gateway", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOPCInstance_storage(t *testing.T) {
 	resName := "opc_compute_instance.test"
 	rInt := acctest.RandInt()
@@ -336,6 +377,36 @@ resource "opc_compute_instance" "test" {
     ip_network = "${opc_compute_ip_network.foo.id}"
     vnic = "ip-network-test-%d"
     shared_network = false
+  }
+}
+
+data "opc_compute_network_interface" "test" {
+  instance_id = "${opc_compute_instance.test.id}"
+  instance_name = "${opc_compute_instance.test.name}"
+  interface = "eth0"
+}
+`, rInt, rInt, rInt)
+}
+
+func testAccInstanceIPNetworkingDefaultGateway(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_ip_network" "foo" {
+  name = "testing-ip-network-%d"
+  description = "testing-ip-network-instance"
+  ip_address_prefix = "10.1.12.0/24"
+}
+
+resource "opc_compute_instance" "test" {
+  name = "acc-test-instance-%d"
+  label = "TestAccOPCInstance_ipNetwork"
+  shape = "oc3"
+  image_list = "/oracle/public/oel_6.7_apaas_16.4.5_1610211300"
+  networking_info {
+    index = 0
+    ip_network = "${opc_compute_ip_network.foo.id}"
+    vnic = "ip-network-test-%d"
+    shared_network = false
+		is_default_gateway = true
   }
 }
 

--- a/vendor/github.com/hashicorp/go-oracle-terraform/compute/instances.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/compute/instances.go
@@ -252,6 +252,10 @@ type NetworkingInfo struct {
 	// Required
 	IPNetwork string `json:"ipnetwork,omitempty"`
 	// IP Network only.
+	// Set interface as default gateway for all traffic
+	// Optional
+	IsDefaultGateway bool `json:"is_default_gateway,omitempty"`
+	// IP Network only.
 	// The hexadecimal MAC Address of the interface
 	// Optional
 	MACAddress string `json:"address,omitempty"`

--- a/vendor/github.com/hashicorp/go-oracle-terraform/compute/storage_volumes.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/compute/storage_volumes.go
@@ -35,7 +35,7 @@ type StorageVolumeKind string
 const (
 	StorageVolumeKindDefault StorageVolumeKind = "/oracle/public/storage/default"
 	StorageVolumeKindLatency StorageVolumeKind = "/oracle/public/storage/latency"
-	StorageVolumeKindSSD     StorageVolumeKind = "/oracle/public/storage/ssd/gp1"
+	StorageVolumeKindSSD     StorageVolumeKind = "/oracle/public/storage/ssd/gpl"
 )
 
 // StorageVolumeInfo represents information retrieved from the service about a Storage Volume.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -262,20 +262,20 @@
 			"versionExact": "v0.4.0"
 		},
 		{
-			"checksumSHA1": "L6NeEU8piRVKbSuzd7U7mYDFUgo=",
+			"checksumSHA1": "iAw1fXm+NCtzcfjwoH9kqG7g0jU=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "d1b0e9affb138d06c32c582d4882ffbfc6497ea2",
-			"revisionTime": "2017-09-14T16:37:18Z",
-			"version": "=v0.4.0",
-			"versionExact": "v0.4.0"
+			"revision": "83d5e12ef842b566a21b0a92753b69bf8fe9b9ca",
+			"revisionTime": "2017-10-23T14:49:57Z",
+			"version": "v0.5.2",
+			"versionExact": "v0.5.2"
 		},
 		{
 			"checksumSHA1": "E7dGmtLqjJnfc+Wz3paDimFVI8I=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "d1b0e9affb138d06c32c582d4882ffbfc6497ea2",
-			"revisionTime": "2017-09-14T16:37:18Z",
-			"version": "=v0.4.0",
-			"versionExact": "v0.4.0"
+			"revision": "83d5e12ef842b566a21b0a92753b69bf8fe9b9ca",
+			"revisionTime": "2017-10-23T14:49:57Z",
+			"version": "v0.5.2",
+			"versionExact": "v0.5.2"
 		},
 		{
 			"checksumSHA1": "JbuYtbJkx3r1BLuCMymkri0Q1BI=",
@@ -288,10 +288,10 @@
 		{
 			"checksumSHA1": "H8V9Z6p2ezWTQmDkKrcnlIYg8q4=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "d1b0e9affb138d06c32c582d4882ffbfc6497ea2",
-			"revisionTime": "2017-09-14T16:37:18Z",
-			"version": "=v0.4.0",
-			"versionExact": "v0.4.0"
+			"revision": "83d5e12ef842b566a21b0a92753b69bf8fe9b9ca",
+			"revisionTime": "2017-10-23T14:49:57Z",
+			"version": "v0.5.2",
+			"versionExact": "v0.5.2"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/website/docs/d/opc_compute_network_interface.html.markdown
+++ b/website/docs/d/opc_compute_network_interface.html.markdown
@@ -38,6 +38,7 @@ output "vnic" {
 * `dns` - Array of DNS servers for the interface.
 * `ip_address` - IP Address assigned to the interface.
 * `ip_network` - The IP Network assigned to the interface.
+* `is_default_gateway` - Whether or not the the interface is the default gateway.
 * `mac_address` - The MAC address of the interface.
 * `model` - The model of the NIC card used.
 * `name_servers` - Array of name servers for the interface.

--- a/website/docs/r/opc_compute_instance.html.markdown
+++ b/website/docs/r/opc_compute_instance.html.markdown
@@ -132,6 +132,7 @@ The following attributes are supported:
 * `ip_address` - (Optional, IP Network Only) IP Address assigned to the interface.
 * `ip_network` - (Optional, IP Network Only) The IP Network assigned to the interface.
 * `mac_address` - (Optional, IP Network Only) The MAC address of the interface.
+* `is_default_gateway` - (Optional, IP Network Only) Specify the interface is to be used as the default gateway for all traffic. Only one interface on an instance can be specified as the default gateway. If the instance has an interface on the shared network, that interface is always used as the default gateway.
 * `model` - (Required, Shared Network Only) The model of the NIC card used. Must be set to `e1000`.
 * `name_servers` - (Optional) Array of name servers for the interface.
 * `nat` - (Optional for IP Networks, Required for the Shared Network) The IP Reservations associated with the interface (IP Network).


### PR DESCRIPTION
Extension of #86.

```
=== RUN   TestAccOPCInstance_ipNetworkIsDefaultGateway
--- PASS: TestAccOPCInstance_ipNetworkIsDefaultGateway (612.91s)
```