### PR TITLE
Removing database service instance from the provider

### DIFF
--- a/opc/import_database_service_instance_test.go
+++ b/opc/import_database_service_instance_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccOPCDatabaseServiceInstance_importBasic(t *testing.T) {
+	t.Skip("Skipping test until we release this resource")
+
 	resourceName := "opc_database_service_instance.test"
 
 	ri := acctest.RandInt()

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -100,7 +100,7 @@ func Provider() terraform.ResourceProvider {
 			"opc_compute_snapshot":                resourceOPCSnapshot(),
 			"opc_storage_container":               resourceOPCStorageContainer(),
 			"opc_storage_object":                  resourceOPCStorageObject(),
-			"opc_database_service_instance":       resourceOPCDatabaseServiceInstance(),
+			// "opc_database_service_instance":       resourceOPCDatabaseServiceInstance(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/opc/resource_database_service_instance_test.go
+++ b/opc/resource_database_service_instance_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccOPCDatabaseServiceInstance_Basic(t *testing.T) {
+	t.Skip("Skipping test until we release this resource")
+
 	ri := acctest.RandInt()
 	config := testAccDatabaseServiceInstanceBasic(ri)
 	resourceName := "opc_database_service_instance.test"
@@ -39,6 +41,8 @@ func TestAccOPCDatabaseServiceInstance_Basic(t *testing.T) {
 }
 
 func TestAccOPCDatabaseServiceInstance_CloudStorage(t *testing.T) {
+	t.Skip("Skipping test until we release this resource")
+
 	ri := acctest.RandInt()
 	config := testAccDatabaseServiceInstanceCloudStorage(ri)
 	resourceName := "opc_database_service_instance.test"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -47,8 +47,6 @@ The following arguments are supported:
 
 * `storage_endpoint` - (Optional) The API endpoint to use, associated with your Oracle Storage Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_STORAGE_ENDPOINT` environment variable.
 
-* `database_endpoint` - (Optional) The API endpoint to use, associated with Oracle Database Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_DATABASE_ENDPOINT` environment variable.
-
 * `max_retries` - (Optional) The maximum number of tries to make for a successful response when operating on resources within Oracle Public Cloud. It can also be sourced from the `OPC_MAX_RETRIES` environment variable. Defaults to 1.
 
 * `insecure` - (Optional) Skips TLS Verification for using self-signed certificates. Should only be used if absolutely needed. Can also via setting the `OPC_INSECURE` environment variable to `true`.


### PR DESCRIPTION
Removing database service instance from the provider until internal discussions are had about where this resource will live