### PR TITLE
F storage auth

### DIFF
--- a/opc/config.go
+++ b/opc/config.go
@@ -34,10 +34,6 @@ type OPCClient struct {
 }
 
 func (c *Config) Client() (*OPCClient, error) {
-	u, err := url.ParseRequestURI(c.Endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("Invalid endpoint URI: %s", err)
-	}
 
 	userAgentString := fmt.Sprintf("HashiCorp-Terraform-v%s", terraform.VersionString())
 
@@ -45,7 +41,6 @@ func (c *Config) Client() (*OPCClient, error) {
 		IdentityDomain: &c.IdentityDomain,
 		Username:       &c.User,
 		Password:       &c.Password,
-		APIEndpoint:    u,
 		MaxRetries:     &c.MaxRetries,
 		UserAgent:      &userAgentString,
 	}
@@ -67,13 +62,19 @@ func (c *Config) Client() (*OPCClient, error) {
 
 	config.HTTPClient = httpClient
 
-	computeClient, err := compute.NewComputeClient(&config)
-	if err != nil {
-		return nil, err
-	}
+	opcClient := &OPCClient{}
 
-	opcClient := &OPCClient{
-		computeClient: computeClient,
+	if c.Endpoint != "" {
+		computeEndpoint, err := url.ParseRequestURI(c.Endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid endpoint URI: %s", err)
+		}
+		config.APIEndpoint = computeEndpoint
+		computeClient, err := compute.NewComputeClient(&config)
+		if err != nil {
+			return nil, err
+		}
+		opcClient.computeClient = computeClient
 	}
 
 	if c.StorageEndpoint != "" {

--- a/opc/config.go
+++ b/opc/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	MaxRetries       int
 	Insecure         bool
 	StorageEndpoint  string
+	StorageServiceId string
 	DatabaseEndpoint string
 }
 
@@ -83,6 +84,9 @@ func (c *Config) Client() (*OPCClient, error) {
 			return nil, fmt.Errorf("Invalid storage endpoint URI: %+v", err)
 		}
 		config.APIEndpoint = storageEndpoint
+		if (c.StorageServiceId) != "" {
+			config.IdentityDomain = &c.StorageServiceId
+		}
 		storageClient, err := storage.NewStorageClient(&config)
 		if err != nil {
 			return nil, err

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -58,6 +58,14 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("OPC_STORAGE_ENDPOINT", nil),
 				Description: "The HTTP endpoint for Oracle Storage operations.",
 			},
+
+			"storage_service_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OPC_STORAGE_SERVICE_ID", nil),
+				Description: "The Storage Service ID. ",
+			},
+
 			"database_endpoint": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -116,6 +124,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		MaxRetries:       d.Get("max_retries").(int),
 		Insecure:         d.Get("insecure").(bool),
 		StorageEndpoint:  d.Get("storage_endpoint").(string),
+		StorageServiceId: d.Get("storage_service_id").(string),
 		DatabaseEndpoint: d.Get("database_endpoint").(string),
 	}
 

--- a/opc/provider.go
+++ b/opc/provider.go
@@ -33,7 +33,7 @@ func Provider() terraform.ResourceProvider {
 
 			"endpoint": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OPC_ENDPOINT", nil),
 				Description: "The HTTP endpoint for OPC API operations.",
 			},

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 * `storage_endpoint` - (Optional) The API endpoint to use, associated with your Oracle Storage Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_STORAGE_ENDPOINT` environment variable.
 
+* `storage_service_id` - (Optional) The Storage Service ID for authentication with the `storage_endpoint`  If not set the `identity_domain` value is used. Can also be set via the `OPC_STORAGE_SERVICE_ID` environment variable.
+
 * `max_retries` - (Optional) The maximum number of tries to make for a successful response when operating on resources within Oracle Public Cloud. It can also be sourced from the `OPC_MAX_RETRIES` environment variable. Defaults to 1.
 
 * `insecure` - (Optional) Skips TLS Verification for using self-signed certificates. Should only be used if absolutely needed. Can also via setting the `OPC_INSECURE` environment variable to `true`.


### PR DESCRIPTION
This update adds a new `storage_service_id` provider attribute that can optionally be used the set the storage authentication service id when its different from the identity domain setting. 

```hcl
provider "opc" {
  user             = "${var.username}"
  password         = "${var.password}"
  identity_domain  = "500099999"
  endpoint         = "https://compute.uscom-east-1.oraclecloud.com"

  storage_service_id = "cloudaccount1"
  storage_endpoint   = "https://uscom-east-1.storage.oraclecloud.com"
}
```

The authentication step now also skips the compute authentication if `endpoint` is not provided - allowing for the provider to be used with accounts that have storage only, and no compute services enabled.