### PR TITLE
F add compute storage attachment

### DIFF
--- a/opc/provider.go
+++ b/opc/provider.go
@@ -102,6 +102,7 @@ func Provider() terraform.ResourceProvider {
 			"opc_compute_orchestrated_instance":   resourceOPCOrchestratedInstance(),
 			"opc_storage_container":               resourceOPCStorageContainer(),
 			"opc_storage_object":                  resourceOPCStorageObject(),
+			"opc_compute_storage_attachment":      resourceOPCStorageAttachment(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/opc/resource_storage_attachment.go
+++ b/opc/resource_storage_attachment.go
@@ -133,7 +133,6 @@ func resourceOPCStorageAttachmentRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	log.Printf("[DEBUG] Read state of storage_attachment %s: %#v", d.Id(), result)
-	d.Set("name", result.Name)
 	d.Set("index", result.Index)
 	d.Set("instance", strings.Split(result.InstanceName, "/")[0])
 	d.Set("storage_volume", result.StorageVolumeName)

--- a/opc/resource_storage_attachment.go
+++ b/opc/resource_storage_attachment.go
@@ -1,0 +1,157 @@
+package opc
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-oracle-terraform/client"
+	"github.com/hashicorp/go-oracle-terraform/compute"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceOPCStorageAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOPCStorageAttachmentCreate,
+		Read:   resourceOPCStorageAttachmentRead,
+		Delete: resourceOPCStorageAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"index": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, 10),
+			},
+			"storage_volume": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceOPCStorageAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Resource state: %#v", d.State())
+
+	log.Print("[DEBUG] Creating storage_attachment")
+
+	volumeName := d.Get("storage_volume").(string)
+	volumeClient := meta.(*OPCClient).computeClient.StorageVolumes()
+	getVolumeInput := compute.GetStorageVolumeInput{
+		Name: volumeName,
+	}
+	storageVolume, err := volumeClient.GetStorageVolume(&getVolumeInput)
+	if err != nil {
+		if client.WasNotFoundError(err) {
+			return fmt.Errorf("Unable to find storage volume: %s", volumeName)
+		}
+		return fmt.Errorf("Error reading storage volume %s: %s", volumeName, err)
+	}
+	if storageVolume == nil {
+		// Volume doesn't exist
+		return fmt.Errorf("Unable to find storage volume: %s", volumeName)
+	}
+
+	instanceName := d.Get("instance").(string)
+	instanceClient := meta.(*OPCClient).computeClient.Instances()
+	getInstanceInput := &compute.GetInstanceIdInput{
+		Name: instanceName,
+	}
+	instance, err := instanceClient.GetInstanceFromName(getInstanceInput)
+	if err != nil {
+		return fmt.Errorf("Unable to find Instance: %s", instanceName)
+	}
+	if instance == nil {
+		return fmt.Errorf("Unable to find Instance: %s", instanceName)
+	}
+
+	volumeIndex := d.Get("index").(int)
+	if !checkForEmptyIndex(instance.Storage, volumeIndex) {
+		return fmt.Errorf("Storage index %d is already in use on instance %s", volumeIndex, instanceName)
+	}
+
+	storageAttachmentClient := meta.(*OPCClient).computeClient.StorageAttachments()
+	input := compute.CreateStorageAttachmentInput{
+		StorageVolumeName: storageVolume.Name,
+		InstanceName:      fmt.Sprintf("%s/%s", instance.Name, instance.ID),
+		Index:             volumeIndex,
+	}
+
+	info, err := storageAttachmentClient.CreateStorageAttachment(&input)
+	if err != nil {
+		return fmt.Errorf("Error creating StorageAttachment: %s", err)
+	}
+
+	d.SetId(info.Name)
+	return resourceOPCStorageAttachmentRead(d, meta)
+}
+
+// Need to confirm that the index specified is not already in use.
+func checkForEmptyIndex(attachments []compute.StorageAttachment, index int) bool {
+	for _, attachment := range attachments {
+		if attachment.Index == index {
+			return false
+		}
+	}
+
+	return true
+}
+
+func resourceOPCStorageAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Resource state: %#v", d.State())
+	computeClient := meta.(*OPCClient).computeClient.StorageAttachments()
+
+	log.Printf("[DEBUG] Reading state of ip reservation %s", d.Id())
+	getInput := compute.GetStorageAttachmentInput{
+		Name: d.Id(),
+	}
+
+	result, err := computeClient.GetStorageAttachment(&getInput)
+	if err != nil {
+		// StorageAttachment does not exist
+		if client.WasNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading storage_attachment %s: %s", d.Id(), err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[DEBUG] Read state of storage_attachment %s: %#v", d.Id(), result)
+	d.Set("name", result.Name)
+	d.Set("index", result.Index)
+	d.Set("instance", strings.Split(result.InstanceName, "/")[0])
+	d.Set("storage_volume", result.StorageVolumeName)
+	return nil
+}
+
+func resourceOPCStorageAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Resource state: %#v", d.State())
+	client := meta.(*OPCClient).computeClient.StorageAttachments()
+	name := d.Id()
+
+	log.Printf("[DEBUG] Deleting StorageAttachment: %v", name)
+
+	input := compute.DeleteStorageAttachmentInput{
+		Name: name,
+	}
+	if err := client.DeleteStorageAttachment(&input); err != nil {
+		return fmt.Errorf("Error deleting StorageAttachment")
+	}
+	return nil
+}

--- a/opc/resource_storage_attachment_test.go
+++ b/opc/resource_storage_attachment_test.go
@@ -1,0 +1,200 @@
+package opc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/compute"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOPCStorageAttachment_Basic(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccStorageAttachmentBasic(ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageAttachmentExists,
+				),
+			},
+		},
+	})
+}
+
+func TestAccOPCStorageAttachment_InvalidIndex(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccStorageAttachmentInvalidIndex(ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("Storage index 1 is already in use"),
+			},
+		},
+	})
+}
+
+func TestAccOPCStorageAttachment_BootAndAttached(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccStorageAttachmentBootAndAttached(ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStorageAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageAttachmentExists,
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckStorageAttachmentExists(s *terraform.State) error {
+	client := testAccProvider.Meta().(*OPCClient).computeClient.StorageAttachments()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opc_compute_storage_attachment" {
+			continue
+		}
+
+		input := compute.GetStorageAttachmentInput{
+			Name: rs.Primary.Attributes["id"],
+		}
+		if _, err := client.GetStorageAttachment(&input); err != nil {
+			return fmt.Errorf("Error retrieving state of StorageAttachment %s: %s", input.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckStorageAttachmentDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*OPCClient).computeClient.StorageAttachments()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opc_compute_storage_attachment" {
+			continue
+		}
+
+		input := compute.GetStorageAttachmentInput{
+			Name: rs.Primary.Attributes["name"],
+		}
+		if info, err := client.GetStorageAttachment(&input); err == nil {
+			return fmt.Errorf("StorageAttachment %s still exists: %#v", input.Name, info)
+		}
+	}
+
+	return nil
+}
+
+func testAccStorageAttachmentBasic(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_storage_volume" "foo" {
+  name = "acc-test-storage-attachment-%d"
+  size = 1
+}
+
+resource "opc_compute_instance" "test" {
+	name = "acc-test-storage-attachment-%d"
+	label = "TestAccOPCInstance_basic"
+	shape = "oc3"
+	image_list = "%s"
+}
+
+resource "opc_compute_storage_attachment" "test" {
+  instance = "${opc_compute_instance.test.name}"
+  storage_volume = "${opc_compute_storage_volume.foo.name}"
+  index = 1
+}
+`, rInt, rInt, TEST_IMAGE_LIST)
+}
+
+func testAccStorageAttachmentInvalidIndex(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_storage_volume" "foo" {
+  name = "acc-test-storage-attachment-%d"
+  size = 1
+}
+
+resource "opc_compute_storage_volume" "bar" {
+  name = "acc-test-storage-attachment-attached-%d"
+  size = 1
+}
+
+resource "opc_compute_instance" "test" {
+	name = "acc-test-storage-attachment-%d"
+	label = "TestAccOPCInstance_basic"
+	shape = "oc3"
+	image_list = "%s"
+  storage {
+		volume = "${opc_compute_storage_volume.bar.name}"
+		index = 1
+	}
+}
+
+resource "opc_compute_storage_attachment" "test" {
+  instance = "${opc_compute_instance.test.name}"
+  storage_volume = "${opc_compute_storage_volume.foo.name}"
+  index = 1
+}
+`, rInt, rInt, rInt, TEST_IMAGE_LIST)
+}
+
+func testAccStorageAttachmentBootAndAttached(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_storage_volume" "foo" {
+  name = "acc-test-storage-attachment-%d"
+  size = 1
+}
+
+resource "opc_compute_image_list" "test" {
+  name = "acc-test-instance-%d"
+  description = "testing instance start-stop"
+}
+
+resource "opc_compute_image_list_entry" "test" {
+  name = "${opc_compute_image_list.test.name}"
+	machine_images = [ "/oracle/public/oel_6.7_apaas_16.4.5_1610211300" ]
+  version = 1
+}
+
+resource "opc_compute_storage_volume" "boot" {
+  name = "acc-test-instance-%d"
+  size = "20"
+  image_list = "${opc_compute_image_list.test.name}"
+  image_list_entry = "${opc_compute_image_list_entry.test.version}"
+  bootable = true
+}
+
+resource "opc_compute_instance" "test" {
+	name = "acc-test-storage-attachment-%d"
+	label = "TestAccOPCInstance_basic"
+	shape = "oc3"
+	image_list = "%s"
+  storage {
+		volume = "${opc_compute_storage_volume.boot.name}"
+		index = 1
+	}
+}
+
+resource "opc_compute_storage_attachment" "test" {
+  instance = "${opc_compute_instance.test.name}"
+  storage_volume = "${opc_compute_storage_volume.foo.name}"
+  index = 2
+}
+`, rInt, rInt, rInt, rInt, TEST_IMAGE_LIST)
+}

--- a/opc/resource_storage_attachment_test.go
+++ b/opc/resource_storage_attachment_test.go
@@ -91,7 +91,7 @@ func testAccCheckStorageAttachmentDestroy(s *terraform.State) error {
 		}
 
 		input := compute.GetStorageAttachmentInput{
-			Name: rs.Primary.Attributes["name"],
+			Name: rs.Primary.Attributes["id"],
 		}
 		if info, err := client.GetStorageAttachment(&input); err == nil {
 			return fmt.Errorf("StorageAttachment %s still exists: %#v", input.Name, info)

--- a/vendor/github.com/hashicorp/go-oracle-terraform/compute/machine_images.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/compute/machine_images.go
@@ -17,7 +17,96 @@ func (c *ComputeClient) MachineImages() *MachineImagesClient {
 		}}
 }
 
-// DeleteMachineImageInput describes the snapshot to delete
+// MahineImage describes an existing Machine Image.
+type MachineImage struct {
+	// account of the associated Object Storage Classic instance
+	Account string `json:"account"`
+
+	// Dictionary of attributes to be made available to the instance
+	Attributes map[string]interface{} `json:"attributes"`
+
+	// Last time when this image was audited
+	Audited string `json:"audited"`
+
+	// Describing the image
+	Description string `json:"description"`
+
+	// Description of the state of the machine image if there is an error
+	ErrorReason string `json:"error_reason"`
+
+	//  dictionary of hypervisor-specific attributes
+	Hypervisor map[string]interface{} `json:"hypervisor"`
+
+	// The format of the image
+	ImageFormat string `json:"image_format"`
+
+	// name of the machine image file uploaded to Object Storage Classic
+	File string `json:"file"`
+
+	// name of the machine image
+	Name string `json:"name"`
+
+	// Indicates that the image file is available in Object Storage Classic
+	NoUpload bool `json:"no_upload"`
+
+	// The OS platform of the image
+	Platform string `json:"platform"`
+
+	// Size values of the image file
+	Sizes map[string]interface{} `json:"sizes"`
+
+	// The state of the uploaded machine image
+	State string `json:"state"`
+
+	// Uniform Resource Identifier
+	URI string `json:"uri"`
+}
+
+// CreateMachineImageInput defines an Image List to be created.
+type CreateMachineImageInput struct {
+	// account of the associated Object Storage Classic instance
+	Account string `json:"account"`
+
+	// Dictionary of attributes to be made available to the instance
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+
+	// Describing the image
+	Description string `json:"description,omitempty"`
+
+	// name of the machine image file uploaded to Object Storage Classic
+	File string `json:"file,omitempty"`
+
+	// name of the machine image
+	Name string `json:"name"`
+
+	// Indicates that the image file is available in Object Storage Classic
+	NoUpload bool `json:"no_upload"`
+
+	// Size values of the image file
+	Sizes map[string]interface{} `json:"sizes"`
+}
+
+// CreateMachineImage creates a new Machine Image with the given parameters.
+func (c *MachineImagesClient) CreateMachineImage(createInput *CreateMachineImageInput) (*MachineImage, error) {
+	var machineImage MachineImage
+
+	// If `sizes` is not set then is mst be defaulted to {"total": 0}
+	if createInput.Sizes == nil {
+		createInput.Sizes = map[string]interface{}{"total": 0}
+	}
+
+	// `no_upload` must always be true
+	createInput.NoUpload = true
+
+	createInput.Name = c.getQualifiedName(createInput.Name)
+	if err := c.createResource(createInput, &machineImage); err != nil {
+		return nil, err
+	}
+
+	return c.success(&machineImage)
+}
+
+// DeleteMachineImageInput describes the MachineImage to delete
 type DeleteMachineImageInput struct {
 	// The name of the MachineImage
 	Name string `json:name`
@@ -26,4 +115,29 @@ type DeleteMachineImageInput struct {
 // DeleteMachineImage deletes the MachineImage with the given name.
 func (c *MachineImagesClient) DeleteMachineImage(deleteInput *DeleteMachineImageInput) error {
 	return c.deleteResource(deleteInput.Name)
+}
+
+// GetMachineList describes the MachineImage to get
+type GetMachineImageInput struct {
+	// account of the associated Object Storage Classic instance
+	Account string `json:"account"`
+	// The name of the Machine Image
+	Name string `json:name`
+}
+
+// GetMachineImage retrieves the MachineImage with the given name.
+func (c *MachineImagesClient) GetMachineImage(getInput *GetMachineImageInput) (*MachineImage, error) {
+	getInput.Name = c.getQualifiedName(getInput.Name)
+
+	var machineImage MachineImage
+	if err := c.getResource(getInput.Name, &machineImage); err != nil {
+		return nil, err
+	}
+
+	return c.success(&machineImage)
+}
+
+func (c *MachineImagesClient) success(result *MachineImage) (*MachineImage, error) {
+	c.unqualify(&result.Name)
+	return result, nil
 }

--- a/vendor/github.com/hashicorp/go-oracle-terraform/compute/storage_volume_attachments.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/compute/storage_volume_attachments.go
@@ -81,6 +81,7 @@ type CreateStorageAttachmentInput struct {
 // CreateStorageAttachment creates a storage attachment attaching the given volume to the given instance at the given index.
 func (c *StorageAttachmentsClient) CreateStorageAttachment(input *CreateStorageAttachmentInput) (*StorageAttachmentInfo, error) {
 	input.InstanceName = c.getQualifiedName(input.InstanceName)
+	input.StorageVolumeName = c.getQualifiedName(input.StorageVolumeName)
 
 	var attachmentInfo *StorageAttachmentInfo
 	if err := c.createResource(&input, &attachmentInfo); err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -256,42 +256,42 @@
 		{
 			"checksumSHA1": "hjQfXn32Tvuu6IJACOTsMzm+AbA=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "dca042671fa15f67c176a03634b2070d1c2d0130",
-			"revisionTime": "2018-01-08T21:05:13Z",
-			"version": "v0.6.5",
-			"versionExact": "v0.6.5"
+			"revision": "d5adade399efe72e371d33ed5152632e7b0d713e",
+			"revisionTime": "2018-01-17T20:28:13Z",
+			"version": "v0.6.7",
+			"versionExact": "v0.6.7"
 		},
 		{
-			"checksumSHA1": "/Cr4IfMQbWiVncb59JBHwvAmO2I=",
+			"checksumSHA1": "Yypqu0KR/aC5MjauOH3rEbktZKU=",
 			"path": "github.com/hashicorp/go-oracle-terraform/compute",
-			"revision": "dca042671fa15f67c176a03634b2070d1c2d0130",
-			"revisionTime": "2018-01-08T21:05:13Z",
-			"version": "v0.6.5",
-			"versionExact": "v0.6.5"
+			"revision": "d5adade399efe72e371d33ed5152632e7b0d713e",
+			"revisionTime": "2018-01-17T20:28:13Z",
+			"version": "v0.6.7",
+			"versionExact": "v0.6.7"
 		},
 		{
 			"checksumSHA1": "E7dGmtLqjJnfc+Wz3paDimFVI8I=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "dca042671fa15f67c176a03634b2070d1c2d0130",
-			"revisionTime": "2018-01-08T21:05:13Z",
-			"version": "v0.6.5",
-			"versionExact": "v0.6.5"
+			"revision": "d5adade399efe72e371d33ed5152632e7b0d713e",
+			"revisionTime": "2018-01-17T20:28:13Z",
+			"version": "v0.6.7",
+			"versionExact": "v0.6.7"
 		},
 		{
 			"checksumSHA1": "NuObCk0/ybL3w++EnltgrB1GQRc=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "dca042671fa15f67c176a03634b2070d1c2d0130",
-			"revisionTime": "2018-01-08T21:05:13Z",
-			"version": "v0.6.5",
-			"versionExact": "v0.6.5"
+			"revision": "d5adade399efe72e371d33ed5152632e7b0d713e",
+			"revisionTime": "2018-01-17T20:28:13Z",
+			"version": "v0.6.7",
+			"versionExact": "v0.6.7"
 		},
 		{
 			"checksumSHA1": "WKErIOzVwmPBcOC0lDp2RUEtSJs=",
 			"path": "github.com/hashicorp/go-oracle-terraform/storage",
-			"revision": "dca042671fa15f67c176a03634b2070d1c2d0130",
-			"revisionTime": "2018-01-08T21:05:13Z",
-			"version": "v0.6.5",
-			"versionExact": "v0.6.5"
+			"revision": "d5adade399efe72e371d33ed5152632e7b0d713e",
+			"revisionTime": "2018-01-17T20:28:13Z",
+			"version": "v0.6.7",
+			"versionExact": "v0.6.7"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/website/docs/r/opc_compute_storage_volume_attachment.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume_attachment.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "opc"
+page_title: "Oracle: opc_compute_storage_volume_attachment"
+sidebar_current: "docs-opc-resource-storage-volume-attachment"
+description: |-
+  Creates and manages a storage volume attachment in an OPC identity domain.
+---
+
+# opc\_compute\_storage\_volume\_attachment
+
+The `opc_compute_storage_volume_attachment` resource creates and manages a storage volume attachment in an OPC identity domain.
+
+## Example Usage
+
+```hcl
+resource "opc_compute_storage_volume" "default" {
+  name = "storage-volume-1"
+  size = 1
+}
+
+resource "opc_compute_instance" "default" {
+	name = "instance-1"
+	label = "instance-1"
+	shape = "oc3"
+	image_list = "/oracle/public/OL_7.2_UEKR4_x86_64"
+}
+
+resource "opc_compute_storage_attachment" "test" {
+  instance = "${opc_compute_instance.default.name}"
+  storage_volume = "${opc_compute_storage_volume.default.name}"
+  index = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance` - (Required) The name of the instance the volume will be attached to.
+
+* `storage_volume` - (Required) The name of the storage volume that will be attached to the instance
+
+* `index` - (Required) The index on the instance that the storage volume will be attached to.

--- a/website/opc.erb
+++ b/website/opc.erb
@@ -91,6 +91,9 @@
                         <li<%= sidebar_current("docs-opc-resource-ssh-key") %>>
                             <a href="/docs/providers/opc/r/opc_compute_ssh_key.html">opc_compute_ssh_key</a>
                         </li>
+                        <li<%= sidebar_current("docs-opc-resource-storage-volume-attachment") %>>
+                            <a href="/docs/providers/opc/r/opc_compute_storage_volume_attachment.html">opc_compute_storage_volume_attachment</a>
+                        </li>
                         <li<%= sidebar_current("docs-opc-resource-storage-volume-type") %>>
                             <a href="/docs/providers/opc/r/opc_compute_storage_volume.html">opc_compute_storage_volume</a>
                         </li>


### PR DESCRIPTION
This PR adds support for storage attachments 

```
make testacc TEST=./opc TESTARGS="-run=TestAccOPCStorageAttachment"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccOPCStorageAttachment -timeout 120m
=== RUN   TestAccOPCStorageAttachment_Basic
--- PASS: TestAccOPCStorageAttachment_Basic (124.33s)
=== RUN   TestAccOPCStorageAttachment_InvalidIndex
--- PASS: TestAccOPCStorageAttachment_InvalidIndex (92.50s)
=== RUN   TestAccOPCStorageAttachment_BootAndAttached
--- PASS: TestAccOPCStorageAttachment_BootAndAttached (130.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opc/opc	346.892s
```