### PR TITLE
Typo for new resource/data source name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATUREs:
 
 * **New Resource:** `r/opc_storage_volume_attachment` ([#112](https://github.com/terraform-providers/terraform-provider-opc/issues/112))
 
-* **New Resource:** `r/opc_machine_image` ([#109](https://github.com/terraform-providers/terraform-provider-opc/issues/109))
+* **New Resource:** `r/opc_compute_machine_image` ([#109](https://github.com/terraform-providers/terraform-provider-opc/issues/109))
 
 BUG FIXES:
 


### PR DESCRIPTION
For Changelog , The new resource/data sources on v1.1.0 is named `opc_machine_image` but in reality is `opc_compute_machine_image`