### PR TITLE
update docs with 'classic' branding

### DIFF
--- a/website/docs/d/opc_compute_image_list_entry.html.markdown
+++ b/website/docs/d/opc_compute_image_list_entry.html.markdown
@@ -3,7 +3,7 @@ layout: "opc"
 page_title: "Oracle: opc_compute_image_list_entry"
 sidebar_current: "docs-opc-datasource-image-list-entry"
 description: |-
-  Gets information about the configuration of an Image List Entry in an OPC identity domain
+  Gets information about the configuration of an Image List Entry within an Oracle Cloud Infrastructure Compute Classic domain.
 ---
 
 # opc\_compute\_image\_list\_entry

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,21 +1,21 @@
 ---
 layout: "opc"
-page_title: "Provider: Oracle Public Cloud"
+page_title: "Provider: Oracle Cloud Infrastructure Classic"
 sidebar_current: "docs-opc-index"
 description: |-
-  The Oracle Public Cloud provider is used to interact with the many resources supported by the Oracle Public Cloud. The provider needs to be configured with credentials for the Oracle Public Cloud API.
+  The Oracle Cloud Infrastructure Classic provider is used to interact with the many resources supported by the Oracle Cloud Infrastructure Classic services. The provider needs to be configured with credentials for the Oracle Cloud Account.
 ---
 
-# Oracle Public Cloud Provider
+# Oracle Cloud Infrastructure Classic Provider
 
-The Oracle Public Cloud provider is used to interact with the many resources supported by the Oracle Public Cloud. The provider needs to be configured with credentials for the Oracle Public Cloud API.
+The Oracle Cloud Infrastructure Classic provider (formerly know as the Oracle Public Cloud provider) is used to interact with the many resources supported by the [Oracle Cloud Infrastructure Classic](http://cloud.oracle.com/classic) and [Oracle Cloud at Customer](https://cloud.oracle.com/cloud-at-customer) infrastructure services. The provider needs to be configured with credentials for the Oracle Cloud Account.
 
 Use the navigation to the left to read about the available resources.
 
 ## Example Usage
 
 ```hcl
-# Configure the Oracle Public Cloud
+# Configure the Oracle Cloud Infrastructure Classic provider
 provider "opc" {
   user            = "..."
   password        = "..."
@@ -40,15 +40,15 @@ The following arguments are supported:
 * `password` - (Optional) The password associated with the username to use. It can also be sourced from
   the `OPC_PASSWORD` environment variable.
 
-* `identity_domain` - (Optional) The Identity Domain or Service Instance ID of the environment to use. It can also be sourced from the `OPC_IDENTITY_DOMAIN` environment variable.  
+* `identity_domain` - (Optional) The Identity Domain name (for Traditional accounts) or Identity Service ID (for IDCS accounts) of the environment to use. It can also be sourced from the `OPC_IDENTITY_DOMAIN` environment variable.  
 
-* `endpoint` - (Optional) The API endpoint to use, associated with your Oracle Public Cloud account. This is known as the `REST Endpoint` within the Oracle portal. It can also be sourced from the `OPC_ENDPOINT` environment variable.
+* `endpoint` - (Optional) The Compute Classic API endpoint to use, associated with your Oracle Cloud Account. This is known as the `REST Endpoint` within the Oracle portal. It can also be sourced from the `OPC_ENDPOINT` environment variable.
 
-* `storage_endpoint` - (Optional) The API endpoint to use, associated with your Oracle Storage Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_STORAGE_ENDPOINT` environment variable.
+* `storage_endpoint` - (Optional) The Storage Classic API endpoint to use, associated with your Oracle Storage Cloud account. This is known as the `REST Endpoint` within the Oracle portal. Can also be set via the `OPC_STORAGE_ENDPOINT` environment variable.
 
 * `storage_service_id` - (Optional) The Storage Service ID for authentication with the `storage_endpoint`  If not set the `identity_domain` value is used. Can also be set via the `OPC_STORAGE_SERVICE_ID` environment variable.
 
-* `max_retries` - (Optional) The maximum number of tries to make for a successful response when operating on resources within Oracle Public Cloud. It can also be sourced from the `OPC_MAX_RETRIES` environment variable. Defaults to 1.
+* `max_retries` - (Optional) The maximum number of tries to make for a successful response when operating on resources. It can also be sourced from the `OPC_MAX_RETRIES` environment variable. Defaults to 1.
 
 * `insecure` - (Optional) Skips TLS Verification for using self-signed certificates. Should only be used if absolutely needed. Can also via setting the `OPC_INSECURE` environment variable to `true`.
 

--- a/website/docs/r/opc_compute_acl.html.markdown
+++ b/website/docs/r/opc_compute_acl.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_acl"
 sidebar_current: "docs-opc-resource-acl"
 description: |-
-  Creates and manages an ACL in an OPC identity domain.
+  Creates and manages an ACL in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_acl
 
-The ``opc_compute_acl`` resource creates and manages an ACL in an OPC identity domain.
+The ``opc_compute_acl`` resource creates and manages an ACL in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_image_list.html.markdown
+++ b/website/docs/r/opc_compute_image_list.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_image_list"
 sidebar_current: "docs-opc-resource-image-list-type"
 description: |-
-  Creates and manages an Image List in an OPC identity domain.
+  Creates and manages an Image List in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_image\_list
 
-The ``opc_compute_image_list`` resource creates and manages an Image List in an OPC identity domain.
+The ``opc_compute_image_list`` resource creates and manages an Image List in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_image_list_entry.html.markdown
+++ b/website/docs/r/opc_compute_image_list_entry.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_image_list_entry"
 sidebar_current: "docs-opc-resource-image-list-entry"
 description: |-
-  Creates and manages an Image List Entry in an OPC identity domain.
+  Creates and manages an Image List Entry in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_image\_list_entry
 
-The ``opc_compute_image_list_entry`` resource creates and manages an Image List Entry in an OPC identity domain.
+The ``opc_compute_image_list_entry`` resource creates and manages an Image List Entry in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_instance.html.markdown
+++ b/website/docs/r/opc_compute_instance.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_instance"
 sidebar_current: "docs-opc-resource-instance"
 description: |-
-  Creates and manages an instance in an OPC identity domain.
+  Creates and manages an instance in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_instance
 
-The ``opc_compute_instance`` resource creates and manages an instance in an OPC identity domain.
+The ``opc_compute_instance`` resource creates and manages an instance in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ~> **Caution:** The ``opc_compute_instance`` resource can completely delete your
 instance just as easily as it can create it. To avoid costly accidents,

--- a/website/docs/r/opc_compute_ip_address_association.html.markdown
+++ b/website/docs/r/opc_compute_ip_address_association.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_ip_address_association"
 sidebar_current: "docs-opc-resource-ip-address-association"
 description: |-
-  Creates and manages an IP address association in an OPC identity domain, for an IP Network.
+  Creates and manages an IP address association in an Oracle Cloud Infrastructure Compute Classic identity domain, for an IP Network.
 ---
 
 # opc\_compute\_ip\_address\_association
 
-The ``opc_compute_ip_address_association`` resource creates and manages an IP address association between an IP address reservation and a virtual NIC in an OPC identity domain, for an IP Network.
+The ``opc_compute_ip_address_association`` resource creates and manages an IP address association between an IP address reservation and a virtual NIC in an Oracle Cloud Infrastructure Compute Classic identity domain, for an IP Network.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_ip_address_prefix_set.html.markdown
+++ b/website/docs/r/opc_compute_ip_address_prefix_set.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_ip_address_prefix_set"
 sidebar_current: "docs-opc-resource-ip-address-prefix-set"
 description: |-
-  Creates and manages an IP address prefix set in an OPC identity domain.
+  Creates and manages an IP address prefix set in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_ip\_address\_prefix\_set
 
-The ``opc_compute_ip_address_prefix_set`` resource creates and manages an IP address prefix set in an OPC identity domain.
+The ``opc_compute_ip_address_prefix_set`` resource creates and manages an IP address prefix set in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_ip_address_reservation.html.markdown
+++ b/website/docs/r/opc_compute_ip_address_reservation.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_ip_address_reservation"
 sidebar_current: "docs-opc-resource-ip-address-reservation"
 description: |-
-  Creates and manages an IP address reservation in an OPC identity domain for an IP Network.
+  Creates and manages an IP address reservation in an Oracle Cloud Infrastructure Compute Classic identity domain for an IP Network.
 ---
 
 # opc\_compute\_ip\_address\_reservation
 
-The ``opc_compute_ip_address_reservation`` resource creates and manages an IP address reservation in an OPC identity domain, for an IP Network.
+The ``opc_compute_ip_address_reservation`` resource creates and manages an IP address reservation in an Oracle Cloud Infrastructure Compute Classic identity domain, for an IP Network.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_ip_association.html.markdown
+++ b/website/docs/r/opc_compute_ip_association.html.markdown
@@ -3,13 +3,13 @@ layout: "opc"
 page_title: "Oracle: opc_compute_ip_association"
 sidebar_current: "docs-opc-resource-ip-association"
 description: |-
-  Creates and manages an IP association in an OPC identity domain for the Shared Network.
+  Creates and manages an IP association in an Oracle Cloud Infrastructure Compute Classic identity domain for the Shared Network.
 ---
 
 # opc\_compute\_ip\_association
 
 The ``opc_compute_ip_association`` resource creates and manages an association between an IP address and an instance in
-an OPC identity domain, for the Shared Network.
+an Oracle Cloud Infrastructure Compute Classic identity domain, for the Shared Network.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_ip_network.html.markdown
+++ b/website/docs/r/opc_compute_ip_network.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_ip_network"
 sidebar_current: "docs-opc-resource-ip-network"
 description: |-
-  Creates and manages an IP Network
+  Creates and manages an IP Network in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_ip_network
 
-The ``opc_compute_ip_network`` resource creates and manages an IP Network.
+The ``opc_compute_ip_network`` resource creates and manages an IP Network in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_ip_network_exchange.html.markdown
+++ b/website/docs/r/opc_compute_ip_network_exchange.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_ip_network_exchange"
 sidebar_current: "docs-opc-resource-ip-network-exchange"
 description: |-
-  Creates and manages an IP network exchange in an OPC identity domain.
+  Creates and manages an IP network exchange in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_ip\_network\_exchange
 
-The ``opc_compute_ip_network_exchange`` resource creates and manages an IP network exchange in an OPC identity domain.
+The `opc_compute_ip_network_exchange` resource creates and manages an IP network exchange in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_ip_reservation.html.markdown
+++ b/website/docs/r/opc_compute_ip_reservation.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_ip_reservation"
 sidebar_current: "docs-opc-resource-ip-reservation"
 description: |-
-  Creates and manages an IP reservation in an OPC identity domain for the Shared Network.
+  Creates and manages an IP reservation in an Oracle Cloud Infrastructure Compute Classic identity domain for the Shared Network.
 ---
 
 # opc\_compute\_ip\_reservation
 
-The ``opc_compute_ip_reservation`` resource creates and manages an IP reservation in an OPC identity domain for the Shared Network.
+The ``opc_compute_ip_reservation`` resource creates and manages an IP reservation in an Oracle Cloud Infrastructure Compute Classic identity domain for the Shared Network.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_machine_image.html.markdown
+++ b/website/docs/r/opc_compute_machine_image.html.markdown
@@ -3,7 +3,7 @@ layout: "opc"
 page_title: "Oracle: opc_compute_machine_image"
 sidebar_current: "docs-opc-resource-machine-image"
 description: |-
-  Creates and manages a Machine Image in a Compute Classic identity domain.
+  Creates and manages a Machine Image in a Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_machine\_image

--- a/website/docs/r/opc_compute_orchestrated_instance.html.markdown
+++ b/website/docs/r/opc_compute_orchestrated_instance.html.markdown
@@ -3,13 +3,13 @@ layout: "opc"
 page_title: "Oracle: opc_compute_orchestrated_instance"
 sidebar_current: "docs-opc-resource-orchestrated-instance"
 description: |-
-  Creates and manages an Orchestration containing a number of instances in an OPC identity domain.
+  Creates and manages an Orchestration containing a number of instances in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_orchestrated\_instance
 
 The `opc_compute_orchestrated_instance` resource creates and manages an orchestration containing a number of
-instances in an OPC identity domain.
+instances in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_route.html.markdown
+++ b/website/docs/r/opc_compute_route.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_route"
 sidebar_current: "docs-opc-resource-route"
 description: |-
-  Creates and manages a Route resource for an IP Network
+  Creates and manages a Route resource for an IP Network in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_route
 
-The `opc_compute_route` resource creates and manages a route for an IP Network.
+The `opc_compute_route` resource creates and manages a route for an IP Network in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_sec_rule.html.markdown
+++ b/website/docs/r/opc_compute_sec_rule.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_sec_rule"
 sidebar_current: "docs-opc-resource-sec-rule"
 description: |-
-  Creates and manages a sec rule in an OPC identity domain.
+  Creates and manages a sec rule in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_sec\_rule
 
-The ``opc_compute_sec_rule`` resource creates and manages a sec rule in an OPC identity domain, which joinstogether a source security list (or security IP list), a destination security list (or security IP list), and a security application.
+The ``opc_compute_sec_rule`` resource creates and manages a sec rule in an Oracle Cloud Infrastructure Compute Classic identity domain, which joins together a source security list (or security IP list), a destination security list (or security IP list), and a security application.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_security_application.html.markdown
+++ b/website/docs/r/opc_compute_security_application.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_security_application"
 sidebar_current: "docs-opc-resource-security-application"
 description: |-
-  Creates and manages a security application in an OPC identity domain.
+  Creates and manages a security application in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_security\_application
 
-The ``opc_compute_security_application`` resource creates and manages a security application in an OPC identity domain.
+The ``opc_compute_security_application`` resource creates and manages a security application in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage (TCP)
 

--- a/website/docs/r/opc_compute_security_association.html.markdown
+++ b/website/docs/r/opc_compute_security_association.html.markdown
@@ -3,13 +3,13 @@ layout: "opc"
 page_title: "Oracle: opc_compute_security_association"
 sidebar_current: "docs-opc-resource-security-association"
 description: |-
-  Creates and manages a security association in an OPC identity domain.
+  Creates and manages a security association in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_security\_association
 
 The ``opc_compute_security_association`` resource creates and manages an association between an instance and a security
-list in an OPC identity domain.
+list in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_security_ip_list.html.markdown
+++ b/website/docs/r/opc_compute_security_ip_list.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_security_ip_list"
 sidebar_current: "docs-opc-resource-security-list"
 description: |-
-  Creates and manages a security IP list in an OPC identity domain.
+  Creates and manages a security IP list in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_security\_ip\_list
 
-The ``opc_compute_security_ip_list`` resource creates and manages a security IP list in an OPC identity domain.
+The ``opc_compute_security_ip_list`` resource creates and manages a security IP list in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_security_list.html.markdown
+++ b/website/docs/r/opc_compute_security_list.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_security_list"
 sidebar_current: "docs-opc-resource-security-list"
 description: |-
-  Creates and manages a security list in an OPC identity domain.
+  Creates and manages a security list in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_security\_list
 
-The ``opc_compute_security_list`` resource creates and manages a security list in an OPC identity domain.
+The ``opc_compute_security_list`` resource creates and manages a security list in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_security_protocol.html.markdown
+++ b/website/docs/r/opc_compute_security_protocol.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_security_protocol"
 sidebar_current: "docs-opc-resource-security-protocol"
 description: |-
-  Creates and manages an security protocol in an OPC identity domain.
+  Creates and manages an security protocol in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_security\_protocol
 
-The ``opc_compute_security_protocol`` resource creates and manages a security protocol in an OPC identity domain.
+The ``opc_compute_security_protocol`` resource creates and manages a security protocol in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_security_rule.html.markdown
+++ b/website/docs/r/opc_compute_security_rule.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_security_rule"
 sidebar_current: "docs-opc-resource-security-rule"
 description: |-
-  Creates and manages a security rule in an OPC identity domain.
+  Creates and manages a security rule in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_security\_rule
 
-The ``opc_compute_security_rule`` resource creates and manages a security rule in an OPC identity domain.
+The ``opc_compute_security_rule`` resource creates and manages a security rule in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_ssh_key.html.markdown
+++ b/website/docs/r/opc_compute_ssh_key.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_ssh_key"
 sidebar_current: "docs-opc-resource-ssh-key"
 description: |-
-  Creates and manages an SSH key in an OPC identity domain.
+  Creates and manages an SSH key in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_ssh_key
 
-The ``opc_compute_ssh_key`` resource creates and manages an SSH key in an OPC identity domain.
+The ``opc_compute_ssh_key`` resource creates and manages an SSH key in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_storage_volume.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_storage_volume"
 sidebar_current: "docs-opc-resource-storage-volume-type"
 description: |-
-  Creates and manages a storage volume in an OPC identity domain.
+  Creates and manages a storage volume in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_storage\_volume
 
-The ``opc_compute_storage_volume`` resource creates and manages a storage volume in an OPC identity domain.
+The ``opc_compute_storage_volume`` resource creates and manages a storage volume in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ~> **Caution:** The ``opc_compute_storage_volume`` resource can completely delete your storage volume just as easily as it can create it. To avoid costly accidents, consider setting [``prevent_destroy``](/docs/configuration/resources.html#prevent_destroy) on your storage volume resources as an extra safety measure.
 

--- a/website/docs/r/opc_compute_storage_volume_attachment.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume_attachment.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_storage_volume_attachment"
 sidebar_current: "docs-opc-resource-storage-volume-attachment"
 description: |-
-  Creates and manages a storage volume attachment in an OPC identity domain.
+  Creates and manages a storage volume attachment in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_storage\_volume\_attachment
 
-The `opc_compute_storage_volume_attachment` resource creates and manages a storage volume attachment in an OPC identity domain.
+The `opc_compute_storage_volume_attachment` resource creates and manages a storage volume attachment in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_storage_volume_snapshot.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume_snapshot.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_storage_volume_snapshot"
 sidebar_current: "docs-opc-resource-storage-volume-snapshot"
 description: |-
-  Creates and manages a storage volume snapshot in an OPC identity domain.
+  Creates and manages a storage volume snapshot in an Oracle Cloud Infrastructure Compute Classic identity domain.
 ---
 
 # opc\_compute\_storage\_volume_snapshot
 
-The ``opc_compute_storage_volume_snapshot`` resource creates and manages a storage volume snapshot in an OPC identity domain.
+The ``opc_compute_storage_volume_snapshot`` resource creates and manages a storage volume snapshot in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_compute_vnic_set.html.markdown
+++ b/website/docs/r/opc_compute_vnic_set.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_compute_vnic_set"
 sidebar_current: "docs-opc-resource-vnic-set"
 description: |-
-  Creates and manages a virtual NIC set in an OPC identity domain
+  Creates and manages a virtual NIC set in an Oracle Cloud Infrastructure Compute Classic identity domain
 ---
 
 # opc\_compute\_vnic\_set
 
-The ``opc_compute_vnic_set`` resource creates and manages a virtual NIC set in an OPC identity domain.
+The ``opc_compute_vnic_set`` resource creates and manages a virtual NIC set in an Oracle Cloud Infrastructure Compute Classic identity domain.
 
 ## Example Usage
 

--- a/website/docs/r/opc_storage_container.html.markdown
+++ b/website/docs/r/opc_storage_container.html.markdown
@@ -3,13 +3,13 @@ layout: "opc"
 page_title: "Oracle: opc_storage_container"
 sidebar_current: "docs-opc-resource-storage-container"
 description: |-
-  Creates and manages a Container in the OPC Storage Domain. `storage_endpoint` must be set in the
+  Creates and manages a Container in the Oracle Cloud Infrastructure Storage Classic service. `storage_endpoint` must be set in the
   provider or environment to manage these resources.
 ---
 
 # opc\_storage\_container
 
-Creates and manages a Container in the OPC Storage Domain. `storage_endpoint` must be set in the
+Creates and manages a Container in the Oracle Cloud Infrastructure Storage Classic service. `storage_endpoint` must be set in the
 provider or environment to manage these resources.
 
 ## Example Usage

--- a/website/docs/r/opc_storage_object.html.markdown
+++ b/website/docs/r/opc_storage_object.html.markdown
@@ -3,12 +3,12 @@ layout: "opc"
 page_title: "Oracle: opc_storage_object"
 sidebar_current: "docs-opc-resource-storage-object"
 description: |-
-  Creates and manages a Object in the OPC Storage Container. `storage_endpoint` must be set in the provider or environment to manage these resources.
+  Creates and manages a Object in an Oracle Cloud Infrastructure Storage Classic container. `storage_endpoint` must be set in the provider or environment to manage these resources.
 ---
 
 # opc\_storage\_object
 
-Creates and manages a Object in the OPC Storage Container. `storage_endpoint` must be set in the provider or environment to manage these resources.
+Creates and manages a Object in an Oracle Cloud Infrastructure Storage Classic container. `storage_endpoint` must be set in the provider or environment to manage these resources.
 
 ## Example Usage
 

--- a/website/opc.erb
+++ b/website/opc.erb
@@ -6,7 +6,7 @@
                     <a href="/docs/providers/index.html">All Providers</a>
                 </li>
                 <li<%= sidebar_current("docs-opc-index") %>>
-                    <a href="/docs/providers/opc/index.html">Oracle Public Cloud Provider</a>
+                    <a href="/docs/providers/opc/index.html">Oracle Cloud Infrastructure Classic Provider</a>
                 </li>
                 <li<%= sidebar_current("docs-opc-datasource") %>>
                 <a href="#">Data Sources</a>


### PR DESCRIPTION
Updates the `opc` provider documentation with the `Oracle Cloud Infrastructure Classic` branding for the Compute Classic and Storage Classic services.
