### PR TITLE
provider/opc: ip_reservation: remove overly strict validation of parent_pool name

### DIFF
--- a/opc/resource_ip_reservation.go
+++ b/opc/resource_ip_reservation.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/go-oracle-terraform/client"
 	"github.com/hashicorp/go-oracle-terraform/compute"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceOPCIPReservation() *schema.Resource {
@@ -35,9 +34,6 @@ func resourceOPCIPReservation() *schema.Resource {
 				Optional: true,
 				Default:  string(compute.PublicReservationPool),
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.PublicReservationPool),
-				}, true),
 			},
 			"tags": tagsForceNewSchema(),
 			"ip": {


### PR DESCRIPTION
In _most_ cases the ippool available to users is `/oracle/public/ippool`. However in some test and development scenarios separate ippools are used with permission restrictions in order to keep resource usage isolated.

This change removes the strict validation of the parent_pool name and allows the pool name to be overridden to a non-default value.
