### PR TITLE
Add checks to all resources to ensure required API client is configured

### DIFF
--- a/opc/config.go
+++ b/opc/config.go
@@ -109,3 +109,17 @@ func (l opcLogger) Log(args ...interface{}) {
 	log.SetFlags(0)
 	log.Print(fmt.Sprintf("go-oracle-terraform: %s", strings.Join(tokens, " ")))
 }
+
+func (c *Client) getComputeClient() (*compute.Client, error) {
+	if c.computeClient == nil {
+		return nil, fmt.Errorf("Compute API client has not been initialized. Ensure the `endpoint` for the Compute Classic REST API Endpoint has been declared in the provider configuration.")
+	}
+	return c.computeClient, nil
+}
+
+func (c *Client) getStorageClient() (*storage.Client, error) {
+	if c.storageClient == nil {
+		return nil, fmt.Errorf("Storage API client has not been initialized. Ensure the `storage_endpoint` for the Object Storage Classic REST API Endpoint has been declared in the provider configuration.")
+	}
+	return c.storageClient, nil
+}

--- a/opc/data_source_image_list_entry.go
+++ b/opc/data_source_image_list_entry.go
@@ -49,7 +49,11 @@ func dataSourceImageListEntry() *schema.Resource {
 }
 
 func dataSourceImageListEntryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.ImageListEntries()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ImageListEntries()
 
 	// Get required attributes
 	image_list := d.Get("image_list").(string)
@@ -61,7 +65,7 @@ func dataSourceImageListEntryRead(d *schema.ResourceData, meta interface{}) erro
 		Version: version,
 	}
 
-	result, err := client.GetImageListEntry(&input)
+	result, err := resClient.GetImageListEntry(&input)
 	if err != nil {
 		return err
 	}

--- a/opc/data_source_ip_address_reservation.go
+++ b/opc/data_source_ip_address_reservation.go
@@ -40,14 +40,18 @@ func dataSourceIPAddressReservation() *schema.Resource {
 }
 
 func dataSourceIPAddressReservationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.IPAddressReservations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressReservations()
 	name := d.Get("name").(string)
 
 	input := compute.GetIPAddressReservationInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetIPAddressReservation(&input)
+	result, err := resClient.GetIPAddressReservation(&input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")

--- a/opc/data_source_ip_reservation.go
+++ b/opc/data_source_ip_reservation.go
@@ -39,14 +39,18 @@ func dataSourceIPReservation() *schema.Resource {
 }
 
 func dataSourceIPReservationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.IPReservations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPReservations()
 	name := d.Get("name").(string)
 
 	input := compute.GetIPReservationInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetIPReservation(&input)
+	result, err := resClient.GetIPReservation(&input)
 	if err != nil {
 		// IP Reservation does not exist
 		if client.WasNotFoundError(err) {

--- a/opc/data_source_machine_image.go
+++ b/opc/data_source_machine_image.go
@@ -82,7 +82,11 @@ func dataSourceMachineImage() *schema.Resource {
 }
 
 func dataSourceMachineImageRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.MachineImages()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.MachineImages()
 
 	// Get required attributes
 	account := d.Get("account").(string)
@@ -93,7 +97,7 @@ func dataSourceMachineImageRead(d *schema.ResourceData, meta interface{}) error 
 		Name:    name,
 	}
 
-	result, err := client.GetMachineImage(&input)
+	result, err := resClient.GetMachineImage(&input)
 	if err != nil {
 		return err
 	}

--- a/opc/data_source_network_interface.go
+++ b/opc/data_source_network_interface.go
@@ -105,7 +105,11 @@ func dataSourceNetworkInterface() *schema.Resource {
 }
 
 func dataSourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.Instances()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Instances()
 
 	// Get required attributes
 	instance_name := d.Get("instance_name").(string)
@@ -118,7 +122,7 @@ func dataSourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) er
 		ID:   instance_id,
 	}
 
-	instance, err := computeClient.GetInstance(input)
+	instance, err := resClient.GetInstance(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")

--- a/opc/data_source_ssh_key.go
+++ b/opc/data_source_ssh_key.go
@@ -32,14 +32,18 @@ func dataSourceSSHKey() *schema.Resource {
 }
 
 func dataSourceSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.SSHKeys()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SSHKeys()
 	name := d.Get("name").(string)
 
 	input := compute.GetSSHKeyInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetSSHKey(&input)
+	result, err := resClient.GetSSHKey(&input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")

--- a/opc/data_source_storage_volume_snapshot.go
+++ b/opc/data_source_storage_volume_snapshot.go
@@ -105,14 +105,18 @@ func dataSourceStorageVolumeSnapshot() *schema.Resource {
 }
 
 func dataSourceStorageVolumeSnapshotRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.StorageVolumeSnapshots()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.StorageVolumeSnapshots()
 
 	name := d.Get("name").(string)
 	input := &compute.GetStorageVolumeSnapshotInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetStorageVolumeSnapshot(input)
+	result, err := resClient.GetStorageVolumeSnapshot(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")

--- a/opc/data_source_virtual_nic.go
+++ b/opc/data_source_virtual_nic.go
@@ -44,7 +44,11 @@ func dataSourceVNIC() *schema.Resource {
 }
 
 func dataSourceVNICRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.VirtNICs()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.VirtNICs()
 
 	name := d.Get("name").(string)
 
@@ -52,7 +56,7 @@ func dataSourceVNICRead(d *schema.ResourceData, meta interface{}) error {
 		Name: name,
 	}
 
-	vnic, err := computeClient.GetVirtualNIC(input)
+	vnic, err := resClient.GetVirtualNIC(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")

--- a/opc/resource_acl.go
+++ b/opc/resource_acl.go
@@ -53,7 +53,11 @@ func resourceOPCACLCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Print("[DEBUG] Creating acl")
 
-	client := meta.(*Client).computeClient.ACLs()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ACLs()
 	input := compute.CreateACLInput{
 		Name:    d.Get("name").(string),
 		Enabled: d.Get("enabled").(bool),
@@ -68,7 +72,7 @@ func resourceOPCACLCreate(d *schema.ResourceData, meta interface{}) error {
 		input.Description = description.(string)
 	}
 
-	info, err := client.CreateACL(&input)
+	info, err := resClient.CreateACL(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating ACL: %s", err)
 	}
@@ -79,14 +83,18 @@ func resourceOPCACLCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceOPCACLRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	computeClient := meta.(*Client).computeClient.ACLs()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ACLs()
 
 	log.Printf("[DEBUG] Reading state of ip reservation %s", d.Id())
 	getInput := compute.GetACLInput{
 		Name: d.Id(),
 	}
 
-	result, err := computeClient.GetACL(&getInput)
+	result, err := resClient.GetACL(&getInput)
 	if err != nil {
 		// ACL does not exist
 		if client.WasNotFoundError(err) {
@@ -117,7 +125,11 @@ func resourceOPCACLUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Print("[DEBUG] Updating acl")
 
-	client := meta.(*Client).computeClient.ACLs()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ACLs()
 	input := compute.UpdateACLInput{
 		Name:    d.Get("name").(string),
 		Enabled: d.Get("enabled").(bool),
@@ -132,7 +144,7 @@ func resourceOPCACLUpdate(d *schema.ResourceData, meta interface{}) error {
 		input.Description = description.(string)
 	}
 
-	info, err := client.UpdateACL(&input)
+	info, err := resClient.UpdateACL(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating ACL: %s", err)
 	}
@@ -143,7 +155,11 @@ func resourceOPCACLUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceOPCACLDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	client := meta.(*Client).computeClient.ACLs()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ACLs()
 	name := d.Id()
 
 	log.Printf("[DEBUG] Deleting ACL: %v", name)
@@ -151,7 +167,7 @@ func resourceOPCACLDelete(d *schema.ResourceData, meta interface{}) error {
 	input := compute.DeleteACLInput{
 		Name: name,
 	}
-	if err := client.DeleteACL(&input); err != nil {
+	if err := resClient.DeleteACL(&input); err != nil {
 		return fmt.Errorf("Error deleting ACL")
 	}
 	return nil

--- a/opc/resource_image_list.go
+++ b/opc/resource_image_list.go
@@ -35,7 +35,11 @@ func resourceOPCImageList() *schema.Resource {
 }
 
 func resourceOPCImageListCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.ImageList()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ImageList()
 
 	name := d.Get("name").(string)
 
@@ -45,7 +49,7 @@ func resourceOPCImageListCreate(d *schema.ResourceData, meta interface{}) error 
 		Default:     d.Get("default").(int),
 	}
 
-	createResult, err := client.CreateImageList(createInput)
+	createResult, err := resClient.CreateImageList(createInput)
 	if err != nil {
 		return err
 	}
@@ -56,7 +60,11 @@ func resourceOPCImageListCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceOPCImageListUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.ImageList()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ImageList()
 
 	name := d.Id()
 
@@ -66,7 +74,7 @@ func resourceOPCImageListUpdate(d *schema.ResourceData, meta interface{}) error 
 		Default:     d.Get("default").(int),
 	}
 
-	_, err := client.UpdateImageList(updateInput)
+	_, err = resClient.UpdateImageList(updateInput)
 	if err != nil {
 		return err
 	}
@@ -75,13 +83,17 @@ func resourceOPCImageListUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceOPCImageListRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.ImageList()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ImageList()
 
 	input := &compute.GetImageListInput{
 		Name: d.Id(),
 	}
 
-	result, err := client.GetImageList(input)
+	result, err := resClient.GetImageList(input)
 	if err != nil {
 		return err
 	}
@@ -99,12 +111,16 @@ func resourceOPCImageListRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCImageListDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.ImageList()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ImageList()
 
 	deleteInput := &compute.DeleteImageListInput{
 		Name: d.Id(),
 	}
-	err := client.DeleteImageList(deleteInput)
+	err = resClient.DeleteImageList(deleteInput)
 	if err != nil {
 		return err
 	}

--- a/opc/resource_image_list_entry.go
+++ b/opc/resource_image_list_entry.go
@@ -62,7 +62,11 @@ func resourceOPCImageListEntry() *schema.Resource {
 }
 
 func resourceOPCImageListEntryCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.ImageListEntries()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ImageListEntries()
 
 	name := d.Get("name").(string)
 	machineImages := expandOPCImageListEntryMachineImages(d)
@@ -84,7 +88,7 @@ func resourceOPCImageListEntryCreate(d *schema.ResourceData, meta interface{}) e
 		createInput.Attributes = attributes
 	}
 
-	_, err := client.CreateImageListEntry(createInput)
+	_, err = resClient.CreateImageListEntry(createInput)
 	if err != nil {
 		return err
 	}
@@ -95,7 +99,11 @@ func resourceOPCImageListEntryCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceOPCImageListEntryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.ImageListEntries()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ImageListEntries()
 
 	// Only parse image list entry ID if delimiter exists
 	name, version, err := parseOPCImageListEntryID(d.Id())
@@ -108,7 +116,7 @@ func resourceOPCImageListEntryRead(d *schema.ResourceData, meta interface{}) err
 		Version: *version,
 	}
 
-	result, err := client.GetImageListEntry(&input)
+	result, err := resClient.GetImageListEntry(&input)
 	if err != nil {
 		return err
 	}
@@ -133,7 +141,11 @@ func resourceOPCImageListEntryRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCImageListEntryDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.ImageListEntries()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.ImageListEntries()
 
 	name, version, err := parseOPCImageListEntryID(d.Id())
 	if err != nil {
@@ -144,7 +156,7 @@ func resourceOPCImageListEntryDelete(d *schema.ResourceData, meta interface{}) e
 		Name:    *name,
 		Version: *version,
 	}
-	err = client.DeleteImageListEntry(deleteInput)
+	err = resClient.DeleteImageListEntry(deleteInput)
 	if err != nil {
 		return err
 	}

--- a/opc/resource_instance.go
+++ b/opc/resource_instance.go
@@ -377,7 +377,11 @@ func resourceInstance() *schema.Resource {
 }
 
 func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.Instances()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Instances()
 
 	// Get Required Attributes
 	input := &compute.CreateInstanceInput{
@@ -437,7 +441,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		input.Tags = tags
 	}
 
-	result, err := client.CreateInstance(input)
+	result, err := resClient.CreateInstance(input)
 	if err != nil {
 		return fmt.Errorf("Error creating instance %s: %s", input.Name, err)
 	}
@@ -450,7 +454,11 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.Instances()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Instances()
 
 	name := d.Get("name").(string)
 
@@ -460,7 +468,7 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Reading state of instance %s", name)
-	result, err := computeClient.GetInstance(input)
+	result, err := resClient.GetInstance(input)
 	if err != nil {
 		// Instance doesn't exist
 		if client.WasNotFoundError(err) {
@@ -564,7 +572,11 @@ func updateInstanceAttributes(d *schema.ResourceData, instance *compute.Instance
 }
 
 func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.Instances()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Instances()
 
 	name := d.Get("name").(string)
 
@@ -584,7 +596,7 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	}
 
-	result, err := client.UpdateInstance(input)
+	result, err := resClient.UpdateInstance(input)
 	if err != nil {
 		return fmt.Errorf("Error updating instance %s: %s", input.Name, err)
 	}
@@ -595,7 +607,11 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.Instances()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Instances()
 
 	name := d.Get("name").(string)
 
@@ -606,7 +622,7 @@ func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] Deleting instance %s", name)
 
-	if err := client.DeleteInstance(input); err != nil {
+	if err := resClient.DeleteInstance(input); err != nil {
 		return fmt.Errorf("Error deleting instance %s: %s", name, err)
 	}
 

--- a/opc/resource_ip_address_association.go
+++ b/opc/resource_ip_address_association.go
@@ -46,7 +46,11 @@ func resourceOPCIPAddressAssociation() *schema.Resource {
 }
 
 func resourceOPCIPAddressAssociationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAddressAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressAssociations()
 
 	input := compute.CreateIPAddressAssociationInput{
 		Name: d.Get("name").(string),
@@ -69,7 +73,7 @@ func resourceOPCIPAddressAssociationCreate(d *schema.ResourceData, meta interfac
 		input.Description = description.(string)
 	}
 
-	info, err := client.CreateIPAddressAssociation(&input)
+	info, err := resClient.CreateIPAddressAssociation(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating IP Address Association: %s", err)
 	}
@@ -79,13 +83,17 @@ func resourceOPCIPAddressAssociationCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceOPCIPAddressAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.IPAddressAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressAssociations()
 	name := d.Id()
 
 	getInput := compute.GetIPAddressAssociationInput{
 		Name: name,
 	}
-	result, err := computeClient.GetIPAddressAssociation(&getInput)
+	result, err := resClient.GetIPAddressAssociation(&getInput)
 	if err != nil {
 		// IP Address Association does not exist
 		if client.WasNotFoundError(err) {
@@ -111,7 +119,11 @@ func resourceOPCIPAddressAssociationRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceOPCIPAddressAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAddressAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressAssociations()
 
 	input := compute.UpdateIPAddressAssociationInput{
 		Name: d.Get("name").(string),
@@ -134,7 +146,7 @@ func resourceOPCIPAddressAssociationUpdate(d *schema.ResourceData, meta interfac
 		input.Description = description.(string)
 	}
 
-	info, err := client.UpdateIPAddressAssociation(&input)
+	info, err := resClient.UpdateIPAddressAssociation(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating IP Address Association: %s", err)
 	}
@@ -144,13 +156,17 @@ func resourceOPCIPAddressAssociationUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceOPCIPAddressAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAddressAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressAssociations()
 	name := d.Id()
 
 	input := compute.DeleteIPAddressAssociationInput{
 		Name: name,
 	}
-	if err := client.DeleteIPAddressAssociation(&input); err != nil {
+	if err := resClient.DeleteIPAddressAssociation(&input); err != nil {
 		return fmt.Errorf("Error deleting IP Address Association: %s", err)
 	}
 	return nil

--- a/opc/resource_ip_address_prefix_set.go
+++ b/opc/resource_ip_address_prefix_set.go
@@ -47,7 +47,11 @@ func resourceOPCIPAddressPrefixSet() *schema.Resource {
 }
 
 func resourceOPCIPAddressPrefixSetCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAddressPrefixSets()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressPrefixSets()
 
 	input := compute.CreateIPAddressPrefixSetInput{
 		Name: d.Get("name").(string),
@@ -67,7 +71,7 @@ func resourceOPCIPAddressPrefixSetCreate(d *schema.ResourceData, meta interface{
 		input.Description = description.(string)
 	}
 
-	info, err := client.CreateIPAddressPrefixSet(&input)
+	info, err := resClient.CreateIPAddressPrefixSet(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating IP Address Prefix Set: %s", err)
 	}
@@ -77,13 +81,17 @@ func resourceOPCIPAddressPrefixSetCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceOPCIPAddressPrefixSetRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.IPAddressPrefixSets()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressPrefixSets()
 
 	input := compute.GetIPAddressPrefixSetInput{
 		Name: d.Id(),
 	}
 
-	result, err := computeClient.GetIPAddressPrefixSet(&input)
+	result, err := resClient.GetIPAddressPrefixSet(&input)
 	if err != nil {
 		// IP Address Prefix Set does not exist
 		if client.WasNotFoundError(err) {
@@ -111,7 +119,11 @@ func resourceOPCIPAddressPrefixSetRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceOPCIPAddressPrefixSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAddressPrefixSets()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressPrefixSets()
 
 	input := compute.UpdateIPAddressPrefixSetInput{
 		Name: d.Get("name").(string),
@@ -131,7 +143,7 @@ func resourceOPCIPAddressPrefixSetUpdate(d *schema.ResourceData, meta interface{
 		input.Description = description.(string)
 	}
 
-	info, err := client.UpdateIPAddressPrefixSet(&input)
+	info, err := resClient.UpdateIPAddressPrefixSet(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating IP Address Prefix Set: %s", err)
 	}
@@ -141,13 +153,17 @@ func resourceOPCIPAddressPrefixSetUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceOPCIPAddressPrefixSetDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAddressPrefixSets()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressPrefixSets()
 	name := d.Id()
 
 	input := compute.DeleteIPAddressPrefixSetInput{
 		Name: name,
 	}
-	if err := client.DeleteIPAddressPrefixSet(&input); err != nil {
+	if err := resClient.DeleteIPAddressPrefixSet(&input); err != nil {
 		return fmt.Errorf("Error deleting IP Address Prefix Set: %s", err)
 	}
 	return nil

--- a/opc/resource_ip_address_reservation.go
+++ b/opc/resource_ip_address_reservation.go
@@ -52,7 +52,11 @@ func resourceOPCIPAddressReservation() *schema.Resource {
 }
 
 func resourceOPCIPAddressReservationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAddressReservations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressReservations()
 
 	input := compute.CreateIPAddressReservationInput{
 		Name:          d.Get("name").(string),
@@ -66,7 +70,7 @@ func resourceOPCIPAddressReservationCreate(d *schema.ResourceData, meta interfac
 		input.Description = description.(string)
 	}
 
-	info, err := client.CreateIPAddressReservation(&input)
+	info, err := resClient.CreateIPAddressReservation(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating IP Address Reservation: %s", err)
 	}
@@ -75,13 +79,17 @@ func resourceOPCIPAddressReservationCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceOPCIPAddressReservationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.IPAddressReservations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressReservations()
 
 	input := compute.GetIPAddressReservationInput{
 		Name: d.Id(),
 	}
 
-	result, err := computeClient.GetIPAddressReservation(&input)
+	result, err := resClient.GetIPAddressReservation(&input)
 	if err != nil {
 		// IP Address Reservation does not exist
 		if client.WasNotFoundError(err) {
@@ -109,7 +117,11 @@ func resourceOPCIPAddressReservationRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceOPCIPAddressReservationUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAddressReservations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressReservations()
 
 	input := compute.UpdateIPAddressReservationInput{
 		Name:          d.Get("name").(string),
@@ -123,7 +135,7 @@ func resourceOPCIPAddressReservationUpdate(d *schema.ResourceData, meta interfac
 		input.Description = description.(string)
 	}
 
-	info, err := client.UpdateIPAddressReservation(&input)
+	info, err := resClient.UpdateIPAddressReservation(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating IP Address Reservation: %s", err)
 	}
@@ -132,13 +144,17 @@ func resourceOPCIPAddressReservationUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceOPCIPAddressReservationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAddressReservations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAddressReservations()
 	name := d.Id()
 
 	input := compute.DeleteIPAddressReservationInput{
 		Name: name,
 	}
-	if err := client.DeleteIPAddressReservation(&input); err != nil {
+	if err := resClient.DeleteIPAddressReservation(&input); err != nil {
 		return fmt.Errorf("Error deleting IP Address Reservation: %+v", err)
 	}
 	return nil

--- a/opc/resource_ip_association.go
+++ b/opc/resource_ip_association.go
@@ -43,12 +43,16 @@ func resourceOPCIPAssociationCreate(d *schema.ResourceData, meta interface{}) er
 	vCable := d.Get("vcable").(string)
 	parentPool := d.Get("parent_pool").(string)
 
-	client := meta.(*Client).computeClient.IPAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAssociations()
 	input := compute.CreateIPAssociationInput{
 		ParentPool: parentPool,
 		VCable:     vCable,
 	}
-	info, err := client.CreateIPAssociation(&input)
+	info, err := resClient.CreateIPAssociation(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating ip association between vcable %s and parent pool %s: %s", vCable, parentPool, err)
 	}
@@ -59,14 +63,18 @@ func resourceOPCIPAssociationCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceOPCIPAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.IPAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAssociations()
 
 	name := d.Id()
 	input := compute.GetIPAssociationInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetIPAssociation(&input)
+	result, err := resClient.GetIPAssociation(&input)
 	if err != nil {
 		// IP Association does not exist
 		if client.WasNotFoundError(err) {
@@ -89,13 +97,17 @@ func resourceOPCIPAssociationRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceOPCIPAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPAssociations()
 
 	name := d.Id()
 	input := compute.DeleteIPAssociationInput{
 		Name: name,
 	}
-	if err := client.DeleteIPAssociation(&input); err != nil {
+	if err := resClient.DeleteIPAssociation(&input); err != nil {
 		return fmt.Errorf("Error deleting ip association '%s': %s", name, err)
 	}
 

--- a/opc/resource_ip_network.go
+++ b/opc/resource_ip_network.go
@@ -58,7 +58,11 @@ func resourceOPCIPNetwork() *schema.Resource {
 }
 
 func resourceOPCIPNetworkCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPNetworks()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPNetworks()
 
 	// Get required attributes
 	name := d.Get("name").(string)
@@ -86,7 +90,7 @@ func resourceOPCIPNetworkCreate(d *schema.ResourceData, meta interface{}) error 
 		input.Tags = tags
 	}
 
-	info, err := client.CreateIPNetwork(input)
+	info, err := resClient.CreateIPNetwork(input)
 	if err != nil {
 		return fmt.Errorf("Error creating IP Network '%s': %v", name, err)
 	}
@@ -97,14 +101,18 @@ func resourceOPCIPNetworkCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceOPCIPNetworkRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.IPNetworks()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPNetworks()
 
 	name := d.Id()
 	input := &compute.GetIPNetworkInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetIPNetwork(input)
+	result, err := resClient.GetIPNetwork(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -131,7 +139,11 @@ func resourceOPCIPNetworkRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCIPNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPNetworks()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPNetworks()
 
 	// Get required attributes
 	name := d.Get("name").(string)
@@ -161,7 +173,7 @@ func resourceOPCIPNetworkUpdate(d *schema.ResourceData, meta interface{}) error 
 		input.Tags = tags
 	}
 
-	info, err := client.UpdateIPNetwork(input)
+	info, err := resClient.UpdateIPNetwork(input)
 	if err != nil {
 		return fmt.Errorf("Error updating IP Network '%s': %v", name, err)
 	}
@@ -172,14 +184,18 @@ func resourceOPCIPNetworkUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceOPCIPNetworkDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPNetworks()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPNetworks()
 
 	name := d.Id()
 	input := &compute.DeleteIPNetworkInput{
 		Name: name,
 	}
 
-	if err := client.DeleteIPNetwork(input); err != nil {
+	if err := resClient.DeleteIPNetwork(input); err != nil {
 		return fmt.Errorf("Error deleting IP Network '%s': %v", name, err)
 	}
 	return nil

--- a/opc/resource_ip_network_exchange.go
+++ b/opc/resource_ip_network_exchange.go
@@ -39,7 +39,11 @@ func resourceOPCIPNetworkExchange() *schema.Resource {
 }
 
 func resourceOPCIPNetworkExchangeCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPNetworkExchanges()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPNetworkExchanges()
 	input := compute.CreateIPNetworkExchangeInput{
 		Name: d.Get("name").(string),
 	}
@@ -54,7 +58,7 @@ func resourceOPCIPNetworkExchangeCreate(d *schema.ResourceData, meta interface{}
 		input.Description = description.(string)
 	}
 
-	info, err := client.CreateIPNetworkExchange(&input)
+	info, err := resClient.CreateIPNetworkExchange(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating IP Network Exchange: %s", err)
 	}
@@ -64,14 +68,18 @@ func resourceOPCIPNetworkExchangeCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceOPCIPNetworkExchangeRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.IPNetworkExchanges()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPNetworkExchanges()
 
 	log.Printf("[DEBUG] Reading state of IP Network Exchange %s", d.Id())
 	input := compute.GetIPNetworkExchangeInput{
 		Name: d.Id(),
 	}
 
-	result, err := computeClient.GetIPNetworkExchange(&input)
+	result, err := resClient.GetIPNetworkExchange(&input)
 	if err != nil {
 		// IP NetworkExchange does not exist
 		if client.WasNotFoundError(err) {
@@ -98,14 +106,18 @@ func resourceOPCIPNetworkExchangeRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceOPCIPNetworkExchangeDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPNetworkExchanges()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPNetworkExchanges()
 	name := d.Id()
 
 	log.Printf("[DEBUG] Deleting IP Network Exchange '%s'", name)
 	input := compute.DeleteIPNetworkExchangeInput{
 		Name: name,
 	}
-	if err := client.DeleteIPNetworkExchange(&input); err != nil {
+	if err := resClient.DeleteIPNetworkExchange(&input); err != nil {
 		return fmt.Errorf("Error deleting IP Network Exchange '%s': %+v", name, err)
 	}
 	return nil

--- a/opc/resource_ip_reservation.go
+++ b/opc/resource_ip_reservation.go
@@ -60,8 +60,12 @@ func resourceOPCIPReservationCreate(d *schema.ResourceData, meta interface{}) er
 		reservation.Tags = tags
 	}
 
-	client := meta.(*Client).computeClient.IPReservations()
-	info, err := client.CreateIPReservation(&reservation)
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPReservations()
+	info, err := resClient.CreateIPReservation(&reservation)
 	if err != nil {
 		return fmt.Errorf("Error creating ip reservation from parent_pool %s with tags=%s: %s",
 			reservation.ParentPool, reservation.Tags, err)
@@ -72,13 +76,17 @@ func resourceOPCIPReservationCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceOPCIPReservationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.IPReservations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPReservations()
 
 	input := compute.GetIPReservationInput{
 		Name: d.Id(),
 	}
 
-	result, err := computeClient.GetIPReservation(&input)
+	result, err := resClient.GetIPReservation(&input)
 	if err != nil {
 		// IP Reservation does not exist
 		if client.WasNotFoundError(err) {
@@ -107,12 +115,16 @@ func resourceOPCIPReservationRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceOPCIPReservationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.IPReservations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.IPReservations()
 
 	input := compute.DeleteIPReservationInput{
 		Name: d.Id(),
 	}
-	if err := client.DeleteIPReservation(&input); err != nil {
+	if err := resClient.DeleteIPReservation(&input); err != nil {
 		return fmt.Errorf("Error deleting ip reservation %s", d.Id())
 	}
 	return nil

--- a/opc/resource_machine_image.go
+++ b/opc/resource_machine_image.go
@@ -92,7 +92,11 @@ func resourceOPCMachineImage() *schema.Resource {
 }
 
 func resourceOPCMachineImageCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.MachineImages()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.MachineImages()
 
 	// Get required attributes
 	name := d.Get("name").(string)
@@ -121,7 +125,7 @@ func resourceOPCMachineImageCreate(d *schema.ResourceData, meta interface{}) err
 		input.Attributes = attributes
 	}
 
-	info, err := client.CreateMachineImage(input)
+	info, err := resClient.CreateMachineImage(input)
 	if err != nil {
 		return fmt.Errorf("Error creating Machine Image '%s': %v", name, err)
 	}
@@ -132,14 +136,18 @@ func resourceOPCMachineImageCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCMachineImageRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.MachineImages()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.MachineImages()
 
 	name := d.Id()
 	input := &compute.GetMachineImageInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetMachineImage(input)
+	result, err := resClient.GetMachineImage(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -180,14 +188,18 @@ func resourceOPCMachineImageRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceOPCMachineImageDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.MachineImages()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.MachineImages()
 
 	name := d.Id()
 	input := &compute.DeleteMachineImageInput{
 		Name: name,
 	}
 
-	if err := client.DeleteMachineImage(input); err != nil {
+	if err := resClient.DeleteMachineImage(input); err != nil {
 		return fmt.Errorf("Error deleting Machine Image '%s': %v", name, err)
 	}
 	return nil

--- a/opc/resource_orchestrated_instance.go
+++ b/opc/resource_orchestrated_instance.go
@@ -63,7 +63,11 @@ func resourceOPCOrchestratedInstanceCreate(d *schema.ResourceData, meta interfac
 
 	log.Print("[DEBUG] Creating Orchestration")
 
-	client := meta.(*Client).computeClient.Orchestrations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Orchestrations()
 	input := compute.CreateOrchestrationInput{
 		Name:         d.Get("name").(string),
 		DesiredState: compute.OrchestrationDesiredState(d.Get("desired_state").(string)),
@@ -85,7 +89,7 @@ func resourceOPCOrchestratedInstanceCreate(d *schema.ResourceData, meta interfac
 	}
 	input.Objects = instances
 
-	info, err := client.CreateOrchestration(&input)
+	info, err := resClient.CreateOrchestration(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating Orchestration: %s", err)
 	}
@@ -96,14 +100,18 @@ func resourceOPCOrchestratedInstanceCreate(d *schema.ResourceData, meta interfac
 
 func resourceOPCOrchestratedInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	computeClient := meta.(*Client).computeClient.Orchestrations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Orchestrations()
 
 	log.Printf("[DEBUG] Reading state of orchestrated instance %s", d.Id())
 	getInput := compute.GetOrchestrationInput{
 		Name: d.Id(),
 	}
 
-	result, err := computeClient.GetOrchestration(&getInput)
+	result, err := resClient.GetOrchestration(&getInput)
 	if err != nil {
 		// Orchestration does not exist
 		if client.WasNotFoundError(err) {
@@ -146,14 +154,18 @@ func resourceOPCOrchestratedInstanceUpdate(d *schema.ResourceData, meta interfac
 
 	log.Print("[DEBUG] Updating Orchestration")
 
-	computeClient := meta.(*Client).computeClient.Orchestrations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Orchestrations()
 
 	// Obtain orchestration so we can grab the instance information
 	getInput := compute.GetOrchestrationInput{
 		Name: d.Id(),
 	}
 
-	result, err := computeClient.GetOrchestration(&getInput)
+	result, err := resClient.GetOrchestration(&getInput)
 	if err != nil {
 		// Orchestration does not exist
 		if client.WasNotFoundError(err) {
@@ -186,7 +198,7 @@ func resourceOPCOrchestratedInstanceUpdate(d *schema.ResourceData, meta interfac
 
 	input.Objects = result.Objects
 
-	info, err := computeClient.UpdateOrchestration(&input)
+	info, err := resClient.UpdateOrchestration(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating Orchestration: %s", err)
 	}
@@ -196,7 +208,11 @@ func resourceOPCOrchestratedInstanceUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceOPCOrchestratedInstanceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.Orchestrations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Orchestrations()
 
 	name := d.Id()
 
@@ -206,7 +222,7 @@ func resourceOPCOrchestratedInstanceDelete(d *schema.ResourceData, meta interfac
 	}
 	log.Printf("[DEBUG] Deleting orchestration %s", name)
 
-	if err := client.DeleteOrchestration(input); err != nil {
+	if err := resClient.DeleteOrchestration(input); err != nil {
 		return fmt.Errorf("Error deleting orchestration %s for instance %s: %s", name, d.Id(), err)
 	}
 

--- a/opc/resource_route.go
+++ b/opc/resource_route.go
@@ -52,7 +52,11 @@ func resourceOPCRoute() *schema.Resource {
 }
 
 func resourceOPCRouteCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.Routes()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Routes()
 
 	// Get Required attributes
 	name := d.Get("name").(string)
@@ -83,7 +87,7 @@ func resourceOPCRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Create Route
-	info, err := client.CreateRoute(input)
+	info, err := resClient.CreateRoute(input)
 	if err != nil {
 		return fmt.Errorf("Error creating route '%s': %v", name, err)
 	}
@@ -94,14 +98,18 @@ func resourceOPCRouteCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCRouteRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.Routes()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Routes()
 
 	name := d.Id()
 	input := &compute.GetRouteInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetRoute(input)
+	result, err := resClient.GetRoute(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -127,7 +135,11 @@ func resourceOPCRouteRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCRouteUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.Routes()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Routes()
 
 	// Get Required attributes
 	name := d.Get("name").(string)
@@ -158,7 +170,7 @@ func resourceOPCRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Create Route
-	info, err := client.UpdateRoute(input)
+	info, err := resClient.UpdateRoute(input)
 	if err != nil {
 		return fmt.Errorf("Error creating route '%s': %v", name, err)
 	}
@@ -169,13 +181,17 @@ func resourceOPCRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCRouteDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.Routes()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.Routes()
 
 	name := d.Id()
 	input := &compute.DeleteRouteInput{
 		Name: name,
 	}
-	if err := client.DeleteRoute(input); err != nil {
+	if err := resClient.DeleteRoute(input); err != nil {
 		return fmt.Errorf("Error deleting route '%s': %v", name, err)
 	}
 	return nil

--- a/opc/resource_sec_rule.go
+++ b/opc/resource_sec_rule.go
@@ -57,7 +57,11 @@ func resourceOPCSecRule() *schema.Resource {
 }
 
 func resourceOPCSecRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecRules()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecRules()
 
 	name := d.Get("name").(string)
 	sourceList := d.Get("source_list").(string)
@@ -79,7 +83,7 @@ func resourceOPCSecRuleCreate(d *schema.ResourceData, meta interface{}) error {
 		input.Description = desc.(string)
 	}
 
-	info, err := client.CreateSecRule(&input)
+	info, err := resClient.CreateSecRule(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating sec rule %s: %s", name, err)
 	}
@@ -90,7 +94,11 @@ func resourceOPCSecRuleCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSecRuleRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.SecRules()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecRules()
 
 	name := d.Id()
 
@@ -98,7 +106,7 @@ func resourceOPCSecRuleRead(d *schema.ResourceData, meta interface{}) error {
 		Name: name,
 	}
 
-	result, err := computeClient.GetSecRule(&input)
+	result, err := resClient.GetSecRule(&input)
 	if err != nil {
 		// Sec Rule does not exist
 		if client.WasNotFoundError(err) {
@@ -125,7 +133,11 @@ func resourceOPCSecRuleRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSecRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecRules()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecRules()
 
 	name := d.Get("name").(string)
 	sourceList := d.Get("source_list").(string)
@@ -147,7 +159,7 @@ func resourceOPCSecRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 		input.Description = desc.(string)
 	}
 
-	_, err := client.UpdateSecRule(&input)
+	_, err = resClient.UpdateSecRule(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating sec rule %s: %s", name, err)
 	}
@@ -156,13 +168,17 @@ func resourceOPCSecRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSecRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecRules()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecRules()
 	name := d.Id()
 
 	input := compute.DeleteSecRuleInput{
 		Name: name,
 	}
-	if err := client.DeleteSecRule(&input); err != nil {
+	if err := resClient.DeleteSecRule(&input); err != nil {
 		return fmt.Errorf("Error deleting sec rule %s: %s", name, err)
 	}
 

--- a/opc/resource_security_application.go
+++ b/opc/resource_security_application.go
@@ -82,7 +82,12 @@ func resourceOPCSecurityApplicationCreate(d *schema.ResourceData, meta interface
 	icmpcode := d.Get("icmpcode").(string)
 	description := d.Get("description").(string)
 
-	client := meta.(*Client).computeClient.SecurityApplications()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityApplications()
+
 	input := compute.CreateSecurityApplicationInput{
 		Name:        name,
 		Description: description,
@@ -91,7 +96,7 @@ func resourceOPCSecurityApplicationCreate(d *schema.ResourceData, meta interface
 		ICMPCode:    compute.SecurityApplicationICMPCode(icmpcode),
 		ICMPType:    compute.SecurityApplicationICMPType(icmptype),
 	}
-	info, err := client.CreateSecurityApplication(&input)
+	info, err := resClient.CreateSecurityApplication(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating security application %s: %s", name, err)
 	}
@@ -102,14 +107,18 @@ func resourceOPCSecurityApplicationCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceOPCSecurityApplicationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.SecurityApplications()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityApplications()
 	name := d.Id()
 
 	input := compute.GetSecurityApplicationInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetSecurityApplication(&input)
+	result, err := resClient.GetSecurityApplication(&input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -134,13 +143,17 @@ func resourceOPCSecurityApplicationRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceOPCSecurityApplicationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityApplications()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityApplications()
 	name := d.Id()
 
 	input := compute.DeleteSecurityApplicationInput{
 		Name: name,
 	}
-	if err := client.DeleteSecurityApplication(&input); err != nil {
+	if err := resClient.DeleteSecurityApplication(&input); err != nil {
 		return fmt.Errorf("Error deleting security application '%s': %s", name, err)
 	}
 	return nil

--- a/opc/resource_security_association.go
+++ b/opc/resource_security_association.go
@@ -41,7 +41,11 @@ func resourceOPCSecurityAssociation() *schema.Resource {
 }
 
 func resourceOPCSecurityAssociationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityAssociations()
 
 	name := d.Get("name").(string)
 	vcable := d.Get("vcable").(string)
@@ -52,7 +56,7 @@ func resourceOPCSecurityAssociationCreate(d *schema.ResourceData, meta interface
 		SecList: seclist,
 		VCable:  vcable,
 	}
-	info, err := client.CreateSecurityAssociation(&input)
+	info, err := resClient.CreateSecurityAssociation(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating security association between vcable %s and security list %s: %s", vcable, seclist, err)
 	}
@@ -63,7 +67,11 @@ func resourceOPCSecurityAssociationCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceOPCSecurityAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.SecurityAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityAssociations()
 
 	name := d.Id()
 
@@ -71,7 +79,7 @@ func resourceOPCSecurityAssociationRead(d *schema.ResourceData, meta interface{}
 		Name: name,
 	}
 
-	result, err := computeClient.GetSecurityAssociation(&input)
+	result, err := resClient.GetSecurityAssociation(&input)
 	if err != nil {
 		// Security Association does not exist
 		if client.WasNotFoundError(err) {
@@ -94,14 +102,18 @@ func resourceOPCSecurityAssociationRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceOPCSecurityAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityAssociations()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityAssociations()
 
 	name := d.Id()
 
 	input := compute.DeleteSecurityAssociationInput{
 		Name: name,
 	}
-	if err := client.DeleteSecurityAssociation(&input); err != nil {
+	if err := resClient.DeleteSecurityAssociation(&input); err != nil {
 		return fmt.Errorf("Error deleting Security Association '%s': %v", name, err)
 	}
 	return nil

--- a/opc/resource_security_ip_list.go
+++ b/opc/resource_security_ip_list.go
@@ -40,7 +40,11 @@ func resourceOPCSecurityIPList() *schema.Resource {
 
 func resourceOPCSecurityIPListCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	client := meta.(*Client).computeClient.SecurityIPLists()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityIPLists()
 
 	ipEntries := d.Get("ip_entries").([]interface{})
 	ipEntryStrings := []string{}
@@ -57,7 +61,7 @@ func resourceOPCSecurityIPListCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[DEBUG] Creating security IP list with %+v", input)
-	info, err := client.CreateSecurityIPList(&input)
+	info, err := resClient.CreateSecurityIPList(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating security IP list %s: %s", input.Name, err)
 	}
@@ -68,7 +72,11 @@ func resourceOPCSecurityIPListCreate(d *schema.ResourceData, meta interface{}) e
 
 func resourceOPCSecurityIPListRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	computeClient := meta.(*Client).computeClient.SecurityIPLists()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityIPLists()
 	name := d.Id()
 
 	log.Printf("[DEBUG] Reading state of security IP list %s", name)
@@ -76,7 +84,7 @@ func resourceOPCSecurityIPListRead(d *schema.ResourceData, meta interface{}) err
 		Name: name,
 	}
 
-	result, err := computeClient.GetSecurityIPList(&input)
+	result, err := resClient.GetSecurityIPList(&input)
 	if err != nil {
 		// Security IP List does not exist
 		if client.WasNotFoundError(err) {
@@ -101,7 +109,11 @@ func resourceOPCSecurityIPListRead(d *schema.ResourceData, meta interface{}) err
 func resourceOPCSecurityIPListUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
 
-	client := meta.(*Client).computeClient.SecurityIPLists()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityIPLists()
 
 	ipEntries := d.Get("ip_entries").([]interface{})
 	ipEntryStrings := []string{}
@@ -117,7 +129,7 @@ func resourceOPCSecurityIPListUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[DEBUG] Updating security IP list with %+v", input)
-	info, err := client.UpdateSecurityIPList(&input)
+	info, err := resClient.UpdateSecurityIPList(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating security IP list %s: %s", input.Name, err)
 	}
@@ -128,14 +140,18 @@ func resourceOPCSecurityIPListUpdate(d *schema.ResourceData, meta interface{}) e
 
 func resourceOPCSecurityIPListDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Resource state: %#v", d.State())
-	client := meta.(*Client).computeClient.SecurityIPLists()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityIPLists()
 	name := d.Id()
 
 	log.Printf("[DEBUG] Deleting security IP list %s", name)
 	input := compute.DeleteSecurityIPListInput{
 		Name: name,
 	}
-	if err := client.DeleteSecurityIPList(&input); err != nil {
+	if err := resClient.DeleteSecurityIPList(&input); err != nil {
 		return fmt.Errorf("Error deleting security IP list %s: %s", name, err)
 	}
 	return nil

--- a/opc/resource_security_list.go
+++ b/opc/resource_security_list.go
@@ -64,14 +64,19 @@ func resourceOPCSecurityListCreate(d *schema.ResourceData, meta interface{}) err
 	policy := d.Get("policy").(string)
 	outboundCIDRPolicy := d.Get("outbound_cidr_policy").(string)
 
-	client := meta.(*Client).computeClient.SecurityLists()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityLists()
+
 	input := compute.CreateSecurityListInput{
 		Name:               name,
 		Description:        description,
 		Policy:             compute.SecurityListPolicy(policy),
 		OutboundCIDRPolicy: compute.SecurityListPolicy(outboundCIDRPolicy),
 	}
-	info, err := client.CreateSecurityList(&input)
+	info, err := resClient.CreateSecurityList(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating security list %s: %s", name, err)
 	}
@@ -82,7 +87,11 @@ func resourceOPCSecurityListCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCSecurityListUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityLists()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityLists()
 
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
@@ -95,7 +104,7 @@ func resourceOPCSecurityListUpdate(d *schema.ResourceData, meta interface{}) err
 		Policy:             compute.SecurityListPolicy(policy),
 		OutboundCIDRPolicy: compute.SecurityListPolicy(outboundCIDRPolicy),
 	}
-	_, err := client.UpdateSecurityList(&input)
+	_, err = resClient.UpdateSecurityList(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating security list %s: %s", name, err)
 	}
@@ -104,7 +113,11 @@ func resourceOPCSecurityListUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCSecurityListRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.SecurityLists()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityLists()
 
 	name := d.Id()
 
@@ -112,7 +125,7 @@ func resourceOPCSecurityListRead(d *schema.ResourceData, meta interface{}) error
 		Name: name,
 	}
 
-	result, err := computeClient.GetSecurityList(&input)
+	result, err := resClient.GetSecurityList(&input)
 	if err != nil {
 		// Security List does not exist
 		if client.WasNotFoundError(err) {
@@ -136,13 +149,17 @@ func resourceOPCSecurityListRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceOPCSecurityListDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityLists()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityLists()
 
 	name := d.Id()
 	input := compute.DeleteSecurityListInput{
 		Name: name,
 	}
-	if err := client.DeleteSecurityList(&input); err != nil {
+	if err := resClient.DeleteSecurityList(&input); err != nil {
 		return fmt.Errorf("Error deleting security list %s: %s", name, err)
 	}
 

--- a/opc/resource_security_protocol.go
+++ b/opc/resource_security_protocol.go
@@ -55,7 +55,12 @@ func resourceOPCSecurityProtocol() *schema.Resource {
 }
 
 func resourceOPCSecurityProtocolCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityProtocols()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityProtocols()
+
 	input := compute.CreateSecurityProtocolInput{
 		Name:       d.Get("name").(string),
 		IPProtocol: d.Get("ip_protocol").(string),
@@ -77,7 +82,7 @@ func resourceOPCSecurityProtocolCreate(d *schema.ResourceData, meta interface{})
 		input.Description = description.(string)
 	}
 
-	info, err := client.CreateSecurityProtocol(&input)
+	info, err := resClient.CreateSecurityProtocol(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating Security Protocol: %s", err)
 	}
@@ -87,13 +92,17 @@ func resourceOPCSecurityProtocolCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceOPCSecurityProtocolRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.SecurityProtocols()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityProtocols()
 
 	input := compute.GetSecurityProtocolInput{
 		Name: d.Id(),
 	}
 
-	result, err := computeClient.GetSecurityProtocol(&input)
+	result, err := resClient.GetSecurityProtocol(&input)
 	if err != nil {
 		// Security Protocol does not exist
 		if client.WasNotFoundError(err) {
@@ -124,7 +133,12 @@ func resourceOPCSecurityProtocolRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceOPCSecurityProtocolUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityProtocols()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityProtocols()
+
 	input := compute.UpdateSecurityProtocolInput{
 		Name:       d.Get("name").(string),
 		IPProtocol: d.Get("ip_protocol").(string),
@@ -145,7 +159,7 @@ func resourceOPCSecurityProtocolUpdate(d *schema.ResourceData, meta interface{})
 		input.Description = description.(string)
 	}
 
-	info, err := client.UpdateSecurityProtocol(&input)
+	info, err := resClient.UpdateSecurityProtocol(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating Security Protocol: %s", err)
 	}
@@ -155,13 +169,17 @@ func resourceOPCSecurityProtocolUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceOPCSecurityProtocolDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityProtocols()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityProtocols()
 	name := d.Id()
 
 	input := compute.DeleteSecurityProtocolInput{
 		Name: name,
 	}
-	if err := client.DeleteSecurityProtocol(&input); err != nil {
+	if err := resClient.DeleteSecurityProtocol(&input); err != nil {
 		return fmt.Errorf("Error deleting Security Protocol: %s", err)
 	}
 	return nil

--- a/opc/resource_security_rule.go
+++ b/opc/resource_security_rule.go
@@ -74,7 +74,12 @@ func resourceOPCSecurityRule() *schema.Resource {
 }
 
 func resourceOPCSecurityRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityRules()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityRules()
+
 	input := compute.CreateSecurityRuleInput{
 		Name:          d.Get("name").(string),
 		FlowDirection: d.Get("flow_direction").(string),
@@ -117,7 +122,7 @@ func resourceOPCSecurityRuleCreate(d *schema.ResourceData, meta interface{}) err
 		input.Description = description.(string)
 	}
 
-	info, err := client.CreateSecurityRule(&input)
+	info, err := resClient.CreateSecurityRule(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating Security Rule: %s", err)
 	}
@@ -127,13 +132,17 @@ func resourceOPCSecurityRuleCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCSecurityRuleRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.SecurityRules()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityRules()
 
 	input := compute.GetSecurityRuleInput{
 		Name: d.Id(),
 	}
 
-	result, err := computeClient.GetSecurityRule(&input)
+	result, err := resClient.GetSecurityRule(&input)
 	if err != nil {
 		// SecurityRule does not exist
 		if client.WasNotFoundError(err) {
@@ -173,7 +182,12 @@ func resourceOPCSecurityRuleRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceOPCSecurityRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityRules()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityRules()
+
 	input := compute.UpdateSecurityRuleInput{
 		Name:          d.Get("name").(string),
 		FlowDirection: d.Get("flow_direction").(string),
@@ -215,7 +229,7 @@ func resourceOPCSecurityRuleUpdate(d *schema.ResourceData, meta interface{}) err
 	if description, ok := d.GetOk("description"); ok {
 		input.Description = description.(string)
 	}
-	info, err := client.UpdateSecurityRule(&input)
+	info, err := resClient.UpdateSecurityRule(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating Security Rule: %s", err)
 	}
@@ -225,13 +239,17 @@ func resourceOPCSecurityRuleUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOPCSecurityRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SecurityRules()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SecurityRules()
 	name := d.Id()
 
 	input := compute.DeleteSecurityRuleInput{
 		Name: name,
 	}
-	if err := client.DeleteSecurityRule(&input); err != nil {
+	if err := resClient.DeleteSecurityRule(&input); err != nil {
 		return fmt.Errorf("Error deleting Security Rule: %s", err)
 	}
 	return nil

--- a/opc/resource_ssh_key.go
+++ b/opc/resource_ssh_key.go
@@ -40,7 +40,11 @@ func resourceOPCSSHKey() *schema.Resource {
 }
 
 func resourceOPCSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SSHKeys()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SSHKeys()
 
 	name := d.Get("name").(string)
 	key := d.Get("key").(string)
@@ -52,7 +56,7 @@ func resourceOPCSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
 		Enabled: enabled,
 	}
 
-	info, err := client.CreateSSHKey(&input)
+	info, err := resClient.CreateSSHKey(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating ssh key %s: %s", name, err)
 	}
@@ -63,7 +67,11 @@ func resourceOPCSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SSHKeys()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SSHKeys()
 
 	name := d.Get("name").(string)
 	key := d.Get("key").(string)
@@ -75,7 +83,7 @@ func resourceOPCSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 		Enabled: enabled,
 	}
 
-	_, err := client.UpdateSSHKey(&input)
+	_, err = resClient.UpdateSSHKey(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating ssh key %s: %s", name, err)
 	}
@@ -84,14 +92,18 @@ func resourceOPCSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.SSHKeys()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SSHKeys()
 	name := d.Id()
 
 	input := compute.GetSSHKeyInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetSSHKey(&input)
+	result, err := resClient.GetSSHKey(&input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -113,13 +125,17 @@ func resourceOPCSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCSSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.SSHKeys()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.SSHKeys()
 	name := d.Id()
 
 	input := compute.DeleteSSHKeyInput{
 		Name: name,
 	}
-	if err := client.DeleteSSHKey(&input); err != nil {
+	if err := resClient.DeleteSSHKey(&input); err != nil {
 		return fmt.Errorf("Error deleting ssh key %s: %s", name, err)
 	}
 

--- a/opc/resource_storage_container.go
+++ b/opc/resource_storage_container.go
@@ -82,9 +82,9 @@ func resourceOPCStorageContainer() *schema.Resource {
 }
 
 func resourceOPCStorageContainerCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).storageClient
-	if client == nil {
-		return fmt.Errorf("Storage Client is not initialized. Make sure to use `storage_endpoint` variable or `OPC_STORAGE_ENDPOINT env variable`")
+	storageClient, err := meta.(*Client).getStorageClient()
+	if err != nil {
+		return err
 	}
 
 	input := storage.CreateContainerInput{
@@ -126,7 +126,7 @@ func resourceOPCStorageContainerCreate(d *schema.ResourceData, meta interface{})
 		input.CustomMetadata = metadata
 	}
 
-	info, err := client.CreateContainer(&input)
+	info, err := storageClient.CreateContainer(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating Storage Container: %s", err)
 	}
@@ -137,9 +137,9 @@ func resourceOPCStorageContainerCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceOPCStorageContainerRead(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*Client).storageClient
-	if storageClient == nil {
-		return fmt.Errorf("Storage Client is not initialized. Make sure to use `storage_endpoint` variable or `OPC_STORAGE_ENDPOINT env variable`")
+	storageClient, err := meta.(*Client).getStorageClient()
+	if err != nil {
+		return err
 	}
 
 	name := d.Id()
@@ -187,16 +187,16 @@ func resourceOPCStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceOPCStorageContainerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).storageClient
-	if client == nil {
-		return fmt.Errorf("Storage Client is not initialized. Make sure to use `storage_endpoint` variable or `OPC_STORAGE_ENDPOINT env variable`")
+	storageClient, err := meta.(*Client).getStorageClient()
+	if err != nil {
+		return err
 	}
 
 	name := d.Id()
 	input := storage.DeleteContainerInput{
 		Name: name,
 	}
-	if err := client.DeleteContainer(&input); err != nil {
+	if err := storageClient.DeleteContainer(&input); err != nil {
 		return fmt.Errorf("Error deleting Storage Container '%s': %s", name, err)
 	}
 
@@ -204,9 +204,9 @@ func resourceOPCStorageContainerDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceOPCStorageContainerUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).storageClient
-	if client == nil {
-		return fmt.Errorf("Storage Client is not initialized. Make sure to use `storage_endpoint` variable or `OPC_STORAGE_ENDPOINT env variable`")
+	storageClient, err := meta.(*Client).getStorageClient()
+	if err != nil {
+		return err
 	}
 
 	input := storage.UpdateContainerInput{
@@ -261,7 +261,7 @@ func resourceOPCStorageContainerUpdate(d *schema.ResourceData, meta interface{})
 		input.CustomMetadata = metadata
 	}
 
-	info, err := client.UpdateContainer(&input)
+	info, err := storageClient.UpdateContainer(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating Storage Container: %s", err)
 	}

--- a/opc/resource_storage_volume.go
+++ b/opc/resource_storage_volume.go
@@ -138,7 +138,11 @@ func resourceOPCStorageVolume() *schema.Resource {
 }
 
 func resourceOPCStorageVolumeCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.StorageVolumes()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.StorageVolumes()
 
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
@@ -170,7 +174,7 @@ func resourceOPCStorageVolumeCreate(d *schema.ResourceData, meta interface{}) er
 		input.SnapshotID = v.(string)
 	}
 
-	info, err := client.CreateStorageVolume(&input)
+	info, err := resClient.CreateStorageVolume(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating storage volume %s: %s", name, err)
 	}
@@ -180,7 +184,11 @@ func resourceOPCStorageVolumeCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceOPCStorageVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.StorageVolumes()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.StorageVolumes()
 
 	name := d.Id()
 	description := d.Get("description").(string)
@@ -199,7 +207,7 @@ func resourceOPCStorageVolumeUpdate(d *schema.ResourceData, meta interface{}) er
 		Tags:           getStringList(d, "tags"),
 		Timeout:        d.Timeout(schema.TimeoutUpdate),
 	}
-	_, err := client.UpdateStorageVolume(&input)
+	_, err = resClient.UpdateStorageVolume(&input)
 	if err != nil {
 		return fmt.Errorf("Error updating storage volume %s: %s", name, err)
 	}
@@ -208,14 +216,18 @@ func resourceOPCStorageVolumeUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceOPCStorageVolumeRead(d *schema.ResourceData, meta interface{}) error {
-	sv := meta.(*Client).computeClient.StorageVolumes()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.StorageVolumes()
 
 	name := d.Id()
 	input := compute.GetStorageVolumeInput{
 		Name: name,
 	}
 
-	result, err := sv.GetStorageVolume(&input)
+	result, err := resClient.GetStorageVolume(&input)
 	if err != nil {
 		// Volume doesn't exist
 		if client.WasNotFoundError(err) {
@@ -257,14 +269,18 @@ func resourceOPCStorageVolumeRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceOPCStorageVolumeDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.StorageVolumes()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.StorageVolumes()
 	name := d.Id()
 
 	input := compute.DeleteStorageVolumeInput{
 		Name:    name,
 		Timeout: d.Timeout(schema.TimeoutDelete),
 	}
-	err := client.DeleteStorageVolume(&input)
+	err = resClient.DeleteStorageVolume(&input)
 	if err != nil {
 		return fmt.Errorf("Error deleting storage volume %s: %s", name, err)
 	}

--- a/opc/resource_storage_volume_snapshot.go
+++ b/opc/resource_storage_volume_snapshot.go
@@ -128,7 +128,11 @@ func resourceOPCStorageVolumeSnapshot() *schema.Resource {
 }
 
 func resourceOPCStorageVolumeSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.StorageVolumeSnapshots()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.StorageVolumeSnapshots()
 
 	// Get required attribute
 	input := &compute.CreateStorageVolumeSnapshotInput{
@@ -160,7 +164,7 @@ func resourceOPCStorageVolumeSnapshotCreate(d *schema.ResourceData, meta interfa
 		input.Tags = tags
 	}
 
-	info, err := client.CreateStorageVolumeSnapshot(input)
+	info, err := resClient.CreateStorageVolumeSnapshot(input)
 	if err != nil {
 		return fmt.Errorf("Error creating snapshot '%s': %v", input.Name, err)
 	}
@@ -170,14 +174,18 @@ func resourceOPCStorageVolumeSnapshotCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceOPCStorageVolumeSnapshotRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.StorageVolumeSnapshots()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.StorageVolumeSnapshots()
 
 	name := d.Id()
 	input := &compute.GetStorageVolumeSnapshotInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetStorageVolumeSnapshot(input)
+	result, err := resClient.GetStorageVolumeSnapshot(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -228,7 +236,11 @@ func resourceOPCStorageVolumeSnapshotRead(d *schema.ResourceData, meta interface
 }
 
 func resourceOPCStorageVolumeSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.StorageVolumeSnapshots()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.StorageVolumeSnapshots()
 
 	name := d.Id()
 
@@ -237,7 +249,7 @@ func resourceOPCStorageVolumeSnapshotDelete(d *schema.ResourceData, meta interfa
 		Timeout: d.Timeout(schema.TimeoutDelete),
 	}
 
-	if err := client.DeleteStorageVolumeSnapshot(input); err != nil {
+	if err := resClient.DeleteStorageVolumeSnapshot(input); err != nil {
 		return fmt.Errorf("Error deleting storage volume snapshot '%s': %v", name, err)
 	}
 

--- a/opc/resource_vnic_set.go
+++ b/opc/resource_vnic_set.go
@@ -49,7 +49,11 @@ func resourceOPCVNICSet() *schema.Resource {
 }
 
 func resourceOPCVNICSetCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.VirtNICSets()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.VirtNICSets()
 
 	name := d.Get("name").(string)
 	desc, descOk := d.GetOk("description")
@@ -77,7 +81,7 @@ func resourceOPCVNICSetCreate(d *schema.ResourceData, meta interface{}) error {
 		input.Tags = tags
 	}
 
-	vnicSet, err := client.CreateVirtualNICSet(input)
+	vnicSet, err := resClient.CreateVirtualNICSet(input)
 	if err != nil {
 		return fmt.Errorf("Error creating Virtual NIC Set: %s", err)
 	}
@@ -88,14 +92,18 @@ func resourceOPCVNICSetCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCVNICSetRead(d *schema.ResourceData, meta interface{}) error {
-	computeClient := meta.(*Client).computeClient.VirtNICSets()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.VirtNICSets()
 
 	name := d.Id()
 	input := &compute.GetVirtualNICSetInput{
 		Name: name,
 	}
 
-	result, err := computeClient.GetVirtualNICSet(input)
+	result, err := resClient.GetVirtualNICSet(input)
 	if err != nil {
 		if client.WasNotFoundError(err) {
 			d.SetId("")
@@ -124,7 +132,11 @@ func resourceOPCVNICSetRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCVNICSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.VirtNICSets()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.VirtNICSets()
 
 	name := d.Id()
 	desc, descOk := d.GetOk("description")
@@ -152,7 +164,7 @@ func resourceOPCVNICSetUpdate(d *schema.ResourceData, meta interface{}) error {
 		input.Tags = tags
 	}
 
-	info, err := client.UpdateVirtualNICSet(input)
+	info, err := resClient.UpdateVirtualNICSet(input)
 	if err != nil {
 		return fmt.Errorf("Error updating Virtual NIC Set: %s", err)
 	}
@@ -162,14 +174,18 @@ func resourceOPCVNICSetUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceOPCVNICSetDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Client).computeClient.VirtNICSets()
+	computeClient, err := meta.(*Client).getComputeClient()
+	if err != nil {
+		return err
+	}
+	resClient := computeClient.VirtNICSets()
 
 	name := d.Id()
 	input := &compute.DeleteVirtualNICSetInput{
 		Name: name,
 	}
 
-	if err := client.DeleteVirtualNICSet(input); err != nil {
+	if err := resClient.DeleteVirtualNICSet(input); err != nil {
 		return fmt.Errorf("Error deleting Virtual NIC Set '%s': %s", name, err)
 	}
 	return nil


### PR DESCRIPTION
This PR addresses issues #122, #116, and #134 for the Terraform crash if the `endpoint` is not declared in the provider configuration.   All resource now check that the required resource SDK client (compute or storage) has been configured/initialized before attempting the call the SDK.  