### PR TITLE
enable trusted certificates

### DIFF
--- a/opc/resource_lbaas_certificate.go
+++ b/opc/resource_lbaas_certificate.go
@@ -48,7 +48,7 @@ func resourceLBaaSSSLCertificate() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"SERVER",
-					// "TRUSTED", TODO disable TRUSTED certs due to deletion issue
+					"TRUSTED",
 				}, true),
 			},
 

--- a/opc/resource_lbaas_certificate.go
+++ b/opc/resource_lbaas_certificate.go
@@ -31,7 +31,7 @@ func resourceLBaaSSSLCertificate() *schema.Resource {
 			},
 			"certificate_chain": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateIsPEMFormat,
 			},

--- a/opc/resource_lbaas_certificate_test.go
+++ b/opc/resource_lbaas_certificate_test.go
@@ -34,31 +34,30 @@ func TestAccLBaaSServerCertificate_ServerCertificate(t *testing.T) {
 	})
 }
 
-// TODO TrustedCertificate Test disabled due to issue deleting certificates
-// func TestAccLBaaSServerCertificate_TrustedCertificate(t *testing.T) {
-// 	rInt := acctest.RandInt()
-// 	resName := "opc_lbaas_certificate.trusted-cert"
-// 	testName := fmt.Sprintf("acctest-%d", rInt)
-//
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:     func() { testAccPreCheck(t) },
-// 		Providers:    testAccProviders,
-// 		CheckDestroy: opcResourceCheck(resName, testAccLBaaSCheckCertificateDestroyed),
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccLBaaSCertificateConfig_TrustedCertificate(rInt),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					opcResourceCheck(resName, testAccLBaaSCheckCertificateExists),
-// 					resource.TestCheckResourceAttr(resName, "name", testName),
-// 					resource.TestCheckResourceAttr(resName, "type", "TRUSTED"),
-// 					resource.TestMatchResourceAttr(resName, "uri", regexp.MustCompile(testName)),
-// 					resource.TestCheckResourceAttrSet(resName, "certificate_body"),
-// 					resource.TestCheckResourceAttrSet(resName, "certificate_chain"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+func TestAccLBaaSServerCertificate_TrustedCertificate(t *testing.T) {
+	rInt := acctest.RandInt()
+	resName := "opc_lbaas_certificate.trusted-cert"
+	testName := fmt.Sprintf("acctest-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resName, testAccLBaaSCheckCertificateDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLBaaSCertificateConfig_TrustedCertificate(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					opcResourceCheck(resName, testAccLBaaSCheckCertificateExists),
+					resource.TestCheckResourceAttr(resName, "name", testName),
+					resource.TestCheckResourceAttr(resName, "type", "TRUSTED"),
+					resource.TestMatchResourceAttr(resName, "uri", regexp.MustCompile(testName)),
+					resource.TestCheckResourceAttrSet(resName, "certificate_body"),
+					resource.TestCheckResourceAttrSet(resName, "certificate_chain"),
+				),
+			},
+		},
+	})
+}
 
 func testAccLBaaSCertificateConfig_ServerCertificate(rInt int) string {
 	return fmt.Sprintf(`

--- a/opc/resource_lbaas_policy_test.go
+++ b/opc/resource_lbaas_policy_test.go
@@ -318,38 +318,37 @@ func TestAccLBaaSPolicy_SSLNegotiationPolicy(t *testing.T) {
 	})
 }
 
-// TODO TrustedCertificatePolicy Test disabled due to issue deleting Trusted certificates.
-// func TestAccLBaaSPolicy_TrustedCertificatePolicy(t *testing.T) {
-// 	rInt := acctest.RandInt()
-// 	resName := "opc_lbaas_policy.trusted_certificate_policy"
-// 	testName := fmt.Sprintf("acctest-%d", rInt)
-//
-// 	// use existing LB instance from environment if set
-// 	lbCount := 0
-// 	lbID := os.Getenv("OPC_TEST_USE_EXISTING_LB")
-// 	if lbID == "" {
-// 		lbCount = 1
-// 		lbID = "${opc_lbaas_load_balancer.test.id}"
-// 	}
-//
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:     func() { testAccPreCheck(t) },
-// 		Providers:    testAccProviders,
-// 		CheckDestroy: opcResourceCheck(resName, testAccLBaaSCheckPolicyDestroyed),
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccLBaaSPolicyConfig_TrustedCertificatePolicy(lbID, rInt, lbCount),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					opcResourceCheck(resName, testAccLBaaSCheckPolicyExists),
-// 					resource.TestCheckResourceAttr(resName, "name", testName),
-// 					resource.TestMatchResourceAttr(resName, "uri", regexp.MustCompile(testName)),
-// 					resource.TestCheckResourceAttr(resName, "trusted_certificate_policy.#", "1"),
-// 					resource.TestCheckResourceAttrSet(resName, "trusted_certificate_policy.0.trusted_certificate"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+func TestAccLBaaSPolicy_TrustedCertificatePolicy(t *testing.T) {
+	rInt := acctest.RandInt()
+	resName := "opc_lbaas_policy.trusted_certificate_policy"
+	testName := fmt.Sprintf("acctest-%d", rInt)
+
+	// use existing LB instance from environment if set
+	lbCount := 0
+	lbID := os.Getenv("OPC_TEST_USE_EXISTING_LB")
+	if lbID == "" {
+		lbCount = 1
+		lbID = "${opc_lbaas_load_balancer.test.id}"
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resName, testAccLBaaSCheckPolicyDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLBaaSPolicyConfig_TrustedCertificatePolicy(lbID, rInt, lbCount),
+				Check: resource.ComposeTestCheckFunc(
+					opcResourceCheck(resName, testAccLBaaSCheckPolicyExists),
+					resource.TestCheckResourceAttr(resName, "name", testName),
+					resource.TestMatchResourceAttr(resName, "uri", regexp.MustCompile(testName)),
+					resource.TestCheckResourceAttr(resName, "trusted_certificate_policy.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "trusted_certificate_policy.0.trusted_certificate"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccLBaaSPolicy_ApplicationCookieStickinessPolicy_Update(t *testing.T) {
 	rInt := acctest.RandInt()


### PR DESCRIPTION
This PR enables option to create "Trusted" Certificates now that the issue deleting trusted certificated has been resolved.

Acceptance tests enabled for the Trusted Certificate and Trusted Certificate Policy resources:

```
$ make testacc TEST=./opc TESTARGS="-run=TestAccLBaaSServerCertificate_TrustedCertificate"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccLBaaSServerCertificate_TrustedCertificate -timeout 120m
=== RUN   TestAccLBaaSServerCertificate_TrustedCertificate
--- PASS: TestAccLBaaSServerCertificate_TrustedCertificate (13.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opc/opc	13.460s
```

```
$ make testacc TEST=./opc TESTARGS="-run=TestAccLBaaSPolicy_TrustedCertificatePolicy"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./opc -v -run=TestAccLBaaSPolicy_TrustedCertificatePolicy -timeout 120m
=== RUN   TestAccLBaaSPolicy_TrustedCertificatePolicy
--- PASS: TestAccLBaaSPolicy_TrustedCertificatePolicy (859.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opc/opc	859.540s
```