### PR TITLE
remove ip_address_pool validation

### DIFF
--- a/opc/resource_ip_address_reservation.go
+++ b/opc/resource_ip_address_reservation.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/go-oracle-terraform/client"
 	"github.com/hashicorp/go-oracle-terraform/compute"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceOPCIPAddressReservation() *schema.Resource {
@@ -29,10 +28,6 @@ func resourceOPCIPAddressReservation() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(compute.PublicIPAddressPool),
-					string(compute.PrivateIPAddressPool),
-				}, true),
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/website/docs/r/opc_compute_ip_address_reservation.html.markdown
+++ b/website/docs/r/opc_compute_ip_address_reservation.html.markdown
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the ip address reservation.
 
-* `ip_address_pool` - (Required) The IP address pool from which you want to reserve an IP address. Must be either `public-ippool` or `cloud-ippool`.
+* `ip_address_pool` - (Required) The IP address pool from which you want to reserve an IP address. Typically one of either `public-ippool` or `cloud-ippool`.
 
 * `description` - (Optional) A description of the ip address reservation.
 


### PR DESCRIPTION
This PR removes the validation for the `ip_address_pool` values to allow for custom IP pool names other then the standard public-ipool and cloud-ippool. 