### PR TITLE
Fix test env

### DIFF
--- a/opc/helpers.go
+++ b/opc/helpers.go
@@ -3,6 +3,7 @@ package opc
 import (
 	"log"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 
@@ -86,4 +87,12 @@ func getLoadBalancerContextFromID(id string) lbaas.LoadBalancerContext {
 		Name:   ids[1],
 	}
 	return lb
+}
+
+// Skip LB tests if environment variable isn't set.
+func checkSkipLBTests() bool {
+	if os.Getenv("OPC_LBAAS_ENDPOINT") == "" {
+		return true
+	}
+	return false
 }

--- a/opc/import_lbaas_listener_test.go
+++ b/opc/import_lbaas_listener_test.go
@@ -1,6 +1,7 @@
 package opc
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -9,6 +10,10 @@ import (
 )
 
 func TestAccLBaaSListener_importBasic(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_listener.test"
 

--- a/opc/import_lbaas_load_balancer_test.go
+++ b/opc/import_lbaas_load_balancer_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccOPCLoadBalancer_importBasic(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	resourceName := "opc_lbaas_load_balancer.test"
 
 	ri := acctest.RandInt()

--- a/opc/import_lbaas_policy_test.go
+++ b/opc/import_lbaas_policy_test.go
@@ -1,6 +1,7 @@
 package opc
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -9,6 +10,10 @@ import (
 )
 
 func TestAccLBaaSPolicy_importBasic(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.application_cookie_stickiness_policy"
 

--- a/opc/import_lbaas_server_pool_test.go
+++ b/opc/import_lbaas_server_pool_test.go
@@ -1,6 +1,7 @@
 package opc
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -9,6 +10,9 @@ import (
 )
 
 func TestAccLBaaSServerPool_importBasic(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_server_pool.test"
 

--- a/opc/provider_test.go
+++ b/opc/provider_test.go
@@ -60,7 +60,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 
 	if config.StorageEndpoint == "" && config.StorageServiceID == "" {
-		t.Fatalf("One of `OPC_STORAGE_ENDPOINT` OR `OPC_STROAGE_SERVICE_ID` must be set to run tests")
+		t.Fatalf("One of `OPC_STORAGE_ENDPOINT` OR `OPC_STORAGE_SERVICE_ID` must be set to run tests")
 	}
 
 	if v := os.Getenv("OPC_LBAAS_ENDPOINT"); v != "" {

--- a/opc/resource_lbaas_certificate_test.go
+++ b/opc/resource_lbaas_certificate_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccLBaaSServerCertificate_ServerCertificate(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_certificate.server-cert"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -35,6 +39,10 @@ func TestAccLBaaSServerCertificate_ServerCertificate(t *testing.T) {
 }
 
 func TestAccLBaaSServerCertificate_TrustedCertificate(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_certificate.trusted-cert"
 	testName := fmt.Sprintf("acctest-%d", rInt)

--- a/opc/resource_lbaas_listener_test.go
+++ b/opc/resource_lbaas_listener_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestAccLBaaSListener_Basic(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_listener.test"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -47,6 +51,10 @@ func TestAccLBaaSListener_Basic(t *testing.T) {
 }
 
 func TestAccLBaaSListener_BasicUpdate(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_listener.test"
 	testName := fmt.Sprintf("acctest-%d", rInt)

--- a/opc/resource_lbaas_load_balancer_test.go
+++ b/opc/resource_lbaas_load_balancer_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestAccLBaaSLoadBalancer_Basic(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
 
 	rInt := acctest.RandInt()
 	config := fmt.Sprintf(testAccLoadBalancerBasic, rInt)
@@ -35,6 +38,9 @@ func TestAccLBaaSLoadBalancer_Basic(t *testing.T) {
 }
 
 func TestAccLBaaSLoadBalancer_BasicUpdate(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
 
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_load_balancer.test"

--- a/opc/resource_lbaas_policy_test.go
+++ b/opc/resource_lbaas_policy_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestAccLBaaSPolicy_ApplicationCookieStickinessPolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.application_cookie_stickiness_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -43,6 +47,10 @@ func TestAccLBaaSPolicy_ApplicationCookieStickinessPolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_CloudGatePolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.cloudgate_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -78,6 +86,10 @@ func TestAccLBaaSPolicy_CloudGatePolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_LoadBalancerCookieStickinessPolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.load_balancer_cookie_stickiness_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -110,6 +122,10 @@ func TestAccLBaaSPolicy_LoadBalancerCookieStickinessPolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_LoadBalancingMechanismPolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.load_balancing_mechanism_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -142,6 +158,10 @@ func TestAccLBaaSPolicy_LoadBalancingMechanismPolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_RateLimitingRequestPolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.rate_limiting_request_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -181,6 +201,10 @@ func TestAccLBaaSPolicy_RateLimitingRequestPolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_RedirectPolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.redirect_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -214,6 +238,10 @@ func TestAccLBaaSPolicy_RedirectPolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_ResourceAccessControlPolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.resource_access_control_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -248,6 +276,10 @@ func TestAccLBaaSPolicy_ResourceAccessControlPolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_SetRequestHeaderPolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.set_request_header_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -284,6 +316,10 @@ func TestAccLBaaSPolicy_SetRequestHeaderPolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_SSLNegotiationPolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.ssl_negotiation_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -319,6 +355,10 @@ func TestAccLBaaSPolicy_SSLNegotiationPolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_TrustedCertificatePolicy(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.trusted_certificate_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -351,6 +391,10 @@ func TestAccLBaaSPolicy_TrustedCertificatePolicy(t *testing.T) {
 }
 
 func TestAccLBaaSPolicy_ApplicationCookieStickinessPolicy_Update(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.application_cookie_stickiness_policy"
 	testName := fmt.Sprintf("acctest-%d", rInt)
@@ -394,6 +438,10 @@ func TestAccLBaaSPolicy_ApplicationCookieStickinessPolicy_Update(t *testing.T) {
 
 // Test to check that policy type can be completely changed successfully
 func TestAccLBaaSPolicy_Update_ChangePolicyType(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_policy.update_policy_type"
 	testName := fmt.Sprintf("acctest-%d", rInt)

--- a/opc/resource_lbaas_server_pool_test.go
+++ b/opc/resource_lbaas_server_pool_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestExpandOriginServers(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
 
 	validServers := []string{
 		"192.168.1.100:8080",
@@ -41,6 +44,10 @@ func TestExpandOriginServers(t *testing.T) {
 }
 
 func TestAccLBaaSServerPool_Basic(t *testing.T) {
+	if checkSkipLBTests() {
+		t.Skip(fmt.Printf("`OPC_LBAAS_ENDPOINT` not set, skipping test"))
+	}
+
 	rInt := acctest.RandInt()
 	resName := "opc_lbaas_server_pool.test"
 	testName := fmt.Sprintf("acctest-%d", rInt)


### PR DESCRIPTION
This PR addresses the test failures we're seeing in TeamCity because our testing account doesn't have LBAAS support. We're also removing having both storage environment variables set. Now, one must be set instead of both. 