### PR TITLE
Updating the vendored sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/go-getter v0.0.0-20180709183828-a33f09ce9fee // indirect
 	github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd // indirect
-	github.com/hashicorp/go-oracle-terraform v0.15.2
+	github.com/hashicorp/go-oracle-terraform v0.16.2
 	github.com/hashicorp/go-plugin v0.0.0-20180331002553-e8d22c780116 // indirect
 	github.com/hashicorp/hcl2 v0.0.0-20180714220537-966851f3097f // indirect
 	github.com/hashicorp/terraform v0.11.12-beta1.0.20190214175014-182daa619826

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20150916205742-d30f09973e19 h1:gb61U/o4ZJ6TRYvZqJUKYidIhJOEAvNyVMesryROxAY=
 github.com/hashicorp/go-multierror v0.0.0-20150916205742-d30f09973e19/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
-github.com/hashicorp/go-oracle-terraform v0.15.2 h1:Cg0pP/IPbuaPG+2NBJkZtu3XLCyOamCdrVFv34XrsHo=
-github.com/hashicorp/go-oracle-terraform v0.15.2/go.mod h1:09jT3Y/OIsjTjQ2+3bkVNPDKqWcGIYYvjB2BEKVUdvc=
+github.com/hashicorp/go-oracle-terraform v0.16.2 h1:rAY3cFVkT1b8eVwYhy2+hx1aDSgR3BrZ7vqE5P9bbWo=
+github.com/hashicorp/go-oracle-terraform v0.16.2/go.mod h1:09jT3Y/OIsjTjQ2+3bkVNPDKqWcGIYYvjB2BEKVUdvc=
 github.com/hashicorp/go-plugin v0.0.0-20180125190438-e53f54cbf51e/go.mod h1:JSqWYsict+jzcj0+xElxyrBQRPNoiWQuddnxArJ7XHQ=
 github.com/hashicorp/go-plugin v0.0.0-20180331002553-e8d22c780116 h1:Y4V/yReWjQo/Ngyc0w6C3EKXKincp4YgvXeo8lI4LrI=
 github.com/hashicorp/go-plugin v0.0.0-20180331002553-e8d22c780116/go.mod h1:JSqWYsict+jzcj0+xElxyrBQRPNoiWQuddnxArJ7XHQ=

--- a/vendor/github.com/hashicorp/go-oracle-terraform/compute/compute_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/compute/compute_client.go
@@ -124,6 +124,18 @@ func (c *Client) getUnqualifiedName(name string) string {
 	}
 
 	nameParts := strings.Split(name, "/")
+
+	if len(nameParts) < 4 {
+		return name
+	}
+
+	// OCI-Classic allows users to specify resources from across different users. We'll check to see if
+	// a user uses a different username and return the orginal if it's different.
+	userName := fmt.Sprintf("/%s/%s", nameParts[1], nameParts[2])
+	if userName != c.getUserName() {
+		return name
+	}
+
 	return strings.Join(nameParts[3:], "/")
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -67,7 +67,7 @@ github.com/hashicorp/go-getter/helper/url
 github.com/hashicorp/go-hclog
 # github.com/hashicorp/go-multierror v0.0.0-20150916205742-d30f09973e19
 github.com/hashicorp/go-multierror
-# github.com/hashicorp/go-oracle-terraform v0.15.2
+# github.com/hashicorp/go-oracle-terraform v0.16.2
 github.com/hashicorp/go-oracle-terraform/client
 github.com/hashicorp/go-oracle-terraform/compute
 github.com/hashicorp/go-oracle-terraform/lbaas


### PR DESCRIPTION
This PR updates the vendored go-oracle-terraform sdk to allow users to specify resources from different users/identity domains. 

Addresses #166 