### PR TITLE
Add subcategories to docs for Terraform Registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 - make test
 - make vet
 - make website-test
+- make test-docscheck
 
 branches:
   only:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -57,5 +57,8 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
+test-docscheck:
+	@sh -c "'$(CURDIR)/scripts/docscheck.sh'"
+
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test docscheck
 

--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+docs=$(ls website/docs/**/*.markdown)
+error=false
+
+for doc in $docs; do
+  dirname=$(dirname "$doc")
+  category=$(basename "$dirname")
+
+
+  case "$category" in
+    "guides")
+      # Guides require a page_title
+      if ! grep "^page_title: " "$doc" > /dev/null; then
+        echo "Guide is missing a page_title: $doc"
+        error=true
+      fi
+      ;;
+
+    "d")
+      # no data sources subcategories
+    ;;
+
+    "r")
+      # Resources and data sources require a subcategory
+      if ! grep "^subcategory: " "$doc" > /dev/null; then
+        echo "Doc is missing a subcategory: $doc"
+        error=true
+      fi
+      ;;
+
+    *)
+      error=true
+      echo "Unknown category \"$category\". " \
+        "Docs can only exist in r/, d/, or guides/ folders."
+      ;;
+  esac
+done
+
+if $error; then
+  exit 1
+fi
+
+exit 0

--- a/website/docs/r/opc_compute_acl.html.markdown
+++ b/website/docs/r/opc_compute_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_acl"
 sidebar_current: "docs-opc-resource-acl"

--- a/website/docs/r/opc_compute_image_list.html.markdown
+++ b/website/docs/r/opc_compute_image_list.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_image_list"
 sidebar_current: "docs-opc-resource-image-list-type"

--- a/website/docs/r/opc_compute_image_list_entry.html.markdown
+++ b/website/docs/r/opc_compute_image_list_entry.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_image_list_entry"
 sidebar_current: "docs-opc-resource-image-list-entry"

--- a/website/docs/r/opc_compute_instance.html.markdown
+++ b/website/docs/r/opc_compute_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_instance"
 sidebar_current: "docs-opc-resource-instance"

--- a/website/docs/r/opc_compute_ip_address_association.html.markdown
+++ b/website/docs/r/opc_compute_ip_address_association.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_ip_address_association"
 sidebar_current: "docs-opc-resource-ip-address-association"

--- a/website/docs/r/opc_compute_ip_address_prefix_set.html.markdown
+++ b/website/docs/r/opc_compute_ip_address_prefix_set.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_ip_address_prefix_set"
 sidebar_current: "docs-opc-resource-ip-address-prefix-set"

--- a/website/docs/r/opc_compute_ip_address_reservation.html.markdown
+++ b/website/docs/r/opc_compute_ip_address_reservation.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_ip_address_reservation"
 sidebar_current: "docs-opc-resource-ip-address-reservation"

--- a/website/docs/r/opc_compute_ip_association.html.markdown
+++ b/website/docs/r/opc_compute_ip_association.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_ip_association"
 sidebar_current: "docs-opc-resource-ip-association"

--- a/website/docs/r/opc_compute_ip_network.html.markdown
+++ b/website/docs/r/opc_compute_ip_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_ip_network"
 sidebar_current: "docs-opc-resource-ip-network"

--- a/website/docs/r/opc_compute_ip_network_exchange.html.markdown
+++ b/website/docs/r/opc_compute_ip_network_exchange.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_ip_network_exchange"
 sidebar_current: "docs-opc-resource-ip-network-exchange"

--- a/website/docs/r/opc_compute_ip_reservation.html.markdown
+++ b/website/docs/r/opc_compute_ip_reservation.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_ip_reservation"
 sidebar_current: "docs-opc-resource-ip-reservation"

--- a/website/docs/r/opc_compute_machine_image.html.markdown
+++ b/website/docs/r/opc_compute_machine_image.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_machine_image"
 sidebar_current: "docs-opc-resource-machine-image"

--- a/website/docs/r/opc_compute_orchestrated_instance.html.markdown
+++ b/website/docs/r/opc_compute_orchestrated_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_orchestrated_instance"
 sidebar_current: "docs-opc-resource-orchestrated-instance"

--- a/website/docs/r/opc_compute_route.html.markdown
+++ b/website/docs/r/opc_compute_route.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_route"
 sidebar_current: "docs-opc-resource-route"

--- a/website/docs/r/opc_compute_sec_rule.html.markdown
+++ b/website/docs/r/opc_compute_sec_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_sec_rule"
 sidebar_current: "docs-opc-resource-sec-rule"

--- a/website/docs/r/opc_compute_security_application.html.markdown
+++ b/website/docs/r/opc_compute_security_application.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_security_application"
 sidebar_current: "docs-opc-resource-security-application"

--- a/website/docs/r/opc_compute_security_association.html.markdown
+++ b/website/docs/r/opc_compute_security_association.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_security_association"
 sidebar_current: "docs-opc-resource-security-association"

--- a/website/docs/r/opc_compute_security_ip_list.html.markdown
+++ b/website/docs/r/opc_compute_security_ip_list.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_security_ip_list"
 sidebar_current: "docs-opc-resource-security-list"

--- a/website/docs/r/opc_compute_security_list.html.markdown
+++ b/website/docs/r/opc_compute_security_list.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_security_list"
 sidebar_current: "docs-opc-resource-security-list"

--- a/website/docs/r/opc_compute_security_protocol.html.markdown
+++ b/website/docs/r/opc_compute_security_protocol.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_security_protocol"
 sidebar_current: "docs-opc-resource-security-protocol"

--- a/website/docs/r/opc_compute_security_rule.html.markdown
+++ b/website/docs/r/opc_compute_security_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_security_rule"
 sidebar_current: "docs-opc-resource-security-rule"

--- a/website/docs/r/opc_compute_ssh_key.html.markdown
+++ b/website/docs/r/opc_compute_ssh_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_ssh_key"
 sidebar_current: "docs-opc-resource-ssh-key"

--- a/website/docs/r/opc_compute_storage_volume.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_storage_volume"
 sidebar_current: "docs-opc-resource-storage-volume-type"

--- a/website/docs/r/opc_compute_storage_volume_attachment.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_storage_volume_attachment"
 sidebar_current: "docs-opc-resource-storage-volume-attachment"

--- a/website/docs/r/opc_compute_storage_volume_snapshot.html.markdown
+++ b/website/docs/r/opc_compute_storage_volume_snapshot.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_storage_volume_snapshot"
 sidebar_current: "docs-opc-resource-storage-volume-snapshot"

--- a/website/docs/r/opc_compute_vnic_set.html.markdown
+++ b/website/docs/r/opc_compute_vnic_set.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_vnic_set"
 sidebar_current: "docs-opc-resource-vnic-set"

--- a/website/docs/r/opc_compute_vpn_endpoint_v2.html.markdown
+++ b/website/docs/r/opc_compute_vpn_endpoint_v2.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Compute Classic"
 layout: "opc"
 page_title: "Oracle: opc_compute_vpn_endpoint_v2"
 sidebar_current: "docs-opc-resource-vpn-endpoint-v2"

--- a/website/docs/r/opc_lbaas_certificate.html.markdown
+++ b/website/docs/r/opc_lbaas_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer Classic"
 layout: "opc"
 page_title: "Oracle: opc_lbaas_certificate"
 sidebar_current: "docs-opc-resource-lbaas-certificate"

--- a/website/docs/r/opc_lbaas_listener.html.markdown
+++ b/website/docs/r/opc_lbaas_listener.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer Classic"
 layout: "opc"
 page_title: "Oracle: opc_lbaas_listener"
 sidebar_current: "docs-opc-resource-opc-lbaas-listener"

--- a/website/docs/r/opc_lbaas_load_balancer.html.markdown
+++ b/website/docs/r/opc_lbaas_load_balancer.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer Classic"
 layout: "opc"
 page_title: "Oracle: opc_lbaas_load_balancer"
 sidebar_current: "docs-opc-resource-lbaas-load-balancer"

--- a/website/docs/r/opc_lbaas_policy.html.markdown
+++ b/website/docs/r/opc_lbaas_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer Classic"
 layout: "opc"
 page_title: "Oracle: opc_lbaas_policy"
 sidebar_current: "docs-opc-resource-lbaas-policy"

--- a/website/docs/r/opc_lbaas_server_pool.html.markdown
+++ b/website/docs/r/opc_lbaas_server_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer Classic"
 layout: "opc"
 page_title: "Oracle: opc_lbaas_server_pool"
 sidebar_current: "docs-opc-resource-lbaas-server-pool"

--- a/website/docs/r/opc_storage_container.html.markdown
+++ b/website/docs/r/opc_storage_container.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage Classic"
 layout: "opc"
 page_title: "Oracle: opc_storage_container"
 sidebar_current: "docs-opc-resource-storage-container"

--- a/website/docs/r/opc_storage_object.html.markdown
+++ b/website/docs/r/opc_storage_object.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage Classic"
 layout: "opc"
 page_title: "Oracle: opc_storage_object"
 sidebar_current: "docs-opc-resource-storage-object"


### PR DESCRIPTION
We will soon be displaying documentation for this provider both on
[terraform.io](https://www.terraform.io/docs/providers/index.html)
and on [the Terraform Registry](https://registry.terraform.io/providers).

Documentation displayed on the Terraform Registry will not use the ERB
layout containing the existing navigation, and will instead build the
navigation dynamically based on the directory and YAML frontmatter of a file.
For providers that group similar resources and data sources by service or
use case (subcategories), we'll need to add this information to the
Markdown source file.

This PR modifies Resource and Data Source documentation source files by
adding a subcategory to the metadata if those files were grouped previously.

For more information about how documentation is rendered on the
Terraform Registry, please see this reference:
[Terraform Registry - Provider Documentation](https://www.terraform.io/docs/registry/providers/docs.html).

* Add Docs Check Script

Add script to check docs compatibility with Terraform Registry
importing.