### PR TITLE
allow instance names with multiple path separators

### DIFF
--- a/opc/resource_instance.go
+++ b/opc/resource_instance.go
@@ -25,11 +25,11 @@ func resourceInstance() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				combined := strings.Split(d.Id(), "/")
-				if len(combined) != 2 {
+				if len(combined) < 2 {
 					return nil, fmt.Errorf("Invalid ID specified. Must be in the form of instance_name/instance_id. Got: %s", d.Id())
 				}
-				d.Set("name", combined[0])
-				d.SetId(combined[1])
+				d.Set("name", strings.Join(combined[0:len(combined)-1], "/"))
+				d.SetId(combined[len(combined)-1])
 				return []*schema.ResourceData{d}, nil
 			},
 		},


### PR DESCRIPTION
Fix to address https://github.com/terraform-providers/terraform-provider-opc/issues/174
also requires update to go-oracle-terraform dependency with fix https://github.com/hashicorp/go-oracle-terraform/pull/187

These changes allow for instance names with one or more path separators